### PR TITLE
make grangers robust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ flate2 = { version = "1.0.26", features = ["zlib"], default-features = false }
 noodles = { version = "0.37.0", features = ["gtf","gff","fasta", "core"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", default-features = true, features = ["env-filter"] }
-polars = { version = "0.29", features = ["lazy","dataframe_arithmetic","sort_multiple", "checked_arithmetic","rows","dtype-struct"]}
+polars = { version = "0.29", features = ["lazy","dataframe_arithmetic","sort_multiple", "checked_arithmetic","rows","dtype-struct", "dtype-categorical"]}
 peak_alloc = "0.2.0"
 bedrs = "0.0.26"
 rust-lapper = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 flate2 = { version = "1.0.26", features = ["zlib"], default-features = false }
-noodles = { version = "0.37.0", features = ["gtf","gff","fasta"] }
+noodles = { version = "0.37.0", features = ["gtf","gff","fasta", "core"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", default-features = true, features = ["env-filter"] }
 polars = { version = "0.29", features = ["lazy","dataframe_arithmetic","sort_multiple", "checked_arithmetic","rows","dtype-struct"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ flate2 = { version = "1.0.26", features = ["zlib"], default-features = false }
 noodles = { version = "0.37.0", features = ["gtf","gff","fasta", "core"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", default-features = true, features = ["env-filter"] }
-polars = { version = "0.29", features = ["lazy","dataframe_arithmetic","sort_multiple", "checked_arithmetic","rows","dtype-struct", "dtype-categorical"]}
+polars = { version = "0.29", features = ["lazy","dataframe_arithmetic","sort_multiple", "checked_arithmetic","rows","dtype-struct", "dtype-categorical", "list_eval","concat_str", "strings"]}
 peak_alloc = "0.2.0"
 bedrs = "0.0.26"
 rust-lapper = "1.1.0"

--- a/a_fake_file
+++ b/a_fake_file
@@ -1,0 +1,2 @@
+chr1	HAVANA	.	10	20	.	+	.	"gene_id ""g1"";gene_name ""gene_1"";"
+chr1	.	.	15	30	.	-	.	"gene_id ""g2"";"

--- a/src/grangers.rs
+++ b/src/grangers.rs
@@ -1,8 +1,9 @@
 mod grangers;
 mod grangers_utils;
+pub mod options;
 pub mod reader;
 pub use grangers::*;
-pub use grangers_utils::FileFormat;
+pub use grangers_utils::{FileFormat, IntervalType};
 pub use reader::GStruct;
 
 // This function traverses the GTF file:

--- a/src/grangers/grangers.rs
+++ b/src/grangers/grangers.rs
@@ -1,6 +1,8 @@
 use crate::grangers::reader;
 use crate::grangers::reader::fasta::SeqInfo;
 use anyhow::{bail, Context};
+use noodles::fasta;
+use noodles::fasta::record::Sequence;
 use polars::lazy::dsl::col;
 use polars::{lazy::prelude::*, prelude::*, series::Series};
 use rust_lapper::{Interval, Lapper};
@@ -13,6 +15,8 @@ use std::{
     ops::{Add, Mul, Sub},
 };
 use tracing::{info, warn};
+
+use super::FileFormat;
 
 const ESSENTIAL_FIELDS: [&str; 4] = ["seqnames", "start", "end", "strand"];
 
@@ -875,6 +879,44 @@ impl Grangers {
         Ok(())
     }
 }
+
+// implement get sequence functions for Grangers
+// impl Grangers {
+//     /// Get the sequences of the intervals in the Grangers object according to a file to the reference.
+//     pub fn get_sequences<T: AsRef<Path>>(&self, file_path: T, file_format: &FileFormat) -> 
+//     anyhow::Result<()>
+//     // anyhow::Result<Vec<fasta::record::Sequence>> 
+//     {
+//         match file_format {
+//             FileFormat::FASTA => {
+//                 if !fai_path.exists() {
+//                     fasta::index(file_path)?;
+//                 }
+//                 self.get_sequences_fasta(file_path, fai_path)
+//             },
+//             _ => {
+//                 bail!("{} is not supported for this function for now.", file_format)
+//             }
+//         }
+//         let mut fasta = fasta::IndexedReader::from_file(file_path)?;
+//         let mut seqs = Vec::with_capacity(self.df.height());
+//         for iv in self.lapper.iter() {
+//             let seq = fasta.fetch(iv.start as u64, iv.stop as u64)?;
+//             seqs.push(seq);
+//         }
+//         Ok(())
+//     }
+//     fn get_sequences_fasta<T: AsRef<Path>>(&self, file_path: T) -> anyhow::Result<Vec<Sequence>> {
+//         let mut fasta = noodles::fasta::IndexedReader::from_file(file_path)?;
+//         let mut seqs = Vec::with_capacity(self.df.height());
+//         for iv in self.lapper.iter() {
+//             let seq = fasta.fetch(iv.start as u64, iv.stop as u64)?;
+//             seqs.push(seq);
+//         }
+//         Ok(())
+//     }
+    
+// }
 
 struct LapperVecs {
     start: Vec<i64>,

--- a/src/grangers/grangers.rs
+++ b/src/grangers/grangers.rs
@@ -1423,6 +1423,8 @@ impl Grangers {
     }
 }
 
+// strandness cannot be processed internally, so we return a tuple of (strand, sequence pointer)
+// so that ppl can process the strandness externally
 pub struct FeatSeqIter <'a> {
     iters: Vec<polars::series::SeriesIter::<'a>>,
     sequence: &'a noodles::fasta::record::Sequence,

--- a/src/grangers/grangers.rs
+++ b/src/grangers/grangers.rs
@@ -1,6 +1,6 @@
 // TODO:
 // 1. gtf writer
-// 2. testing functions for get sequences functions
+// 2. fasta writer
 // 3. test sequence functions using true datasets
 use crate::grangers::grangers_utils::*;
 use crate::grangers::options::*;
@@ -620,7 +620,8 @@ impl Grangers {
         let end = self.get_column_name("end", true)?;
         let strand = self.get_column_name("strand", true)?;
         let gene_id = self.get_column_name("gene_id", true)?;
-        let transcript_id = self.get_column_name("transcript_id", false)?;        let exon_id = self.get_column_name("exon_id", false)?;
+        let transcript_id = self.get_column_name("transcript_id", false)?;
+        // let exon_id = self.get_column_name("exon_id", false)?;
 
         if exon_df.column(gene_id)?.null_count() > 0 {
             bail!("The gene_id column contains null values. Cannot proceed.")
@@ -628,9 +629,9 @@ impl Grangers {
         if exon_df.column(gene_id)?.null_count() > 0 {
             bail!("The gene_id column contains null values. Cannot proceed.")
         }
-        if exon_df.column(exon_id)?.null_count() > 0 {
-            bail!("The exon_id column contains null values. Cannot proceed.")
-        }
+        // if exon_df.column(exon_id)?.null_count() > 0 {
+        //     bail!("The exon_id column contains null values. Cannot proceed.")
+        // }
 
         // make sure that stand is valid:
         // - the exons of each transcript are on the same strand

--- a/src/grangers/grangers.rs
+++ b/src/grangers/grangers.rs
@@ -1204,8 +1204,8 @@ impl IntervalType {
         // -1 is for exclusive
         match self {
             IntervalType::Inclusive(c) => 1 - c,
-            IntervalType::LeftInclusive(c) => 1 - c,
-            IntervalType::RightInclusive(c) => -1 + 1 - c,
+            IntervalType::LeftInclusive(c) => -1 + 1 - c,
+            IntervalType::RightInclusive(c) => 1 - c,
             IntervalType::Exclusive(c) => -1 + 1 - c,
         }
     }
@@ -1214,9 +1214,6 @@ impl IntervalType {
 #[cfg(test)]
 mod tests {
     // use polars::prelude::*;
-
-    use polars::export::rayon::vec;
-
     use super::*;
     use crate::grangers::reader::gtf::{AttributeMode, Attributes, GStruct};
 

--- a/src/grangers/grangers_utils.rs
+++ b/src/grangers/grangers_utils.rs
@@ -9,6 +9,8 @@ pub enum FileFormat {
     BED,
     SAM,
     BAM,
+    FASTA,
+    FASTQ
 }
 
 impl FileFormat {
@@ -35,6 +37,8 @@ impl std::str::FromStr for FileFormat {
             "bed" => FileFormat::BED,
             "sam" => FileFormat::SAM,
             "bam" => FileFormat::BAM,
+            "fasta" => FileFormat::FASTA,
+            "fastq" => FileFormat::FASTQ,
             _ => anyhow::bail!("Cannot parse the file type."),
         };
         Ok(ft)
@@ -49,9 +53,12 @@ impl std::fmt::Display for FileFormat {
             FileFormat::BED => write!(f, "BED"),
             FileFormat::SAM => write!(f, "SAM"),
             FileFormat::BAM => write!(f, "BAM"),
+            FileFormat::FASTA => write!(f, "FASTA"),
+            FileFormat::FASTQ => write!(f, "FASTQ"),
         }
     }
 }
+
 pub const GTFESSENTIALATTRIBUTES: [&str; 3] = ["gene_id", "gene_name", "transcript_id"];
 pub const GFFESSENTIALATTRIBUTES: [&str; 4] = ["ID", "gene_id", "gene_name", "transcript_id"];
 // pub const FIELDS: [&str; 8] = [

--- a/src/grangers/grangers_utils.rs
+++ b/src/grangers/grangers_utils.rs
@@ -1,11 +1,7 @@
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
-use tracing::warn;
-
-use crate::options::FieldColumns;
-
-pub(crate) const VALIDSTRANDS: [&str;2] = ["+", "-"];
+pub(crate) const VALIDSTRANDS: [&str; 2] = ["+", "-"];
 
 #[derive(Copy, Clone)]
 pub enum FileFormat {
@@ -179,4 +175,3 @@ impl IntervalType {
         }
     }
 }
-

--- a/src/grangers/grangers_utils.rs
+++ b/src/grangers/grangers_utils.rs
@@ -60,8 +60,8 @@ impl std::fmt::Display for FileFormat {
     }
 }
 
-pub const GTFESSENTIALATTRIBUTES: [&str; 3] = ["gene_id", "gene_name", "transcript_id"];
-pub const GFFESSENTIALATTRIBUTES: [&str; 4] = ["ID", "gene_id", "gene_name", "transcript_id"];
+pub const GTFESSENTIALATTRIBUTES: [&str; 4] = ["gene_id", "transcript_id", "gene_name", "exon_number"];
+pub const GFFESSENTIALATTRIBUTES: [&str; 5] = ["ID", "gene_id", "gene_name", "transcript_id", "exon_number"];
 // pub const FIELDS: [&str; 8] = [
 //     "seqid",
 //     "source",

--- a/src/grangers/grangers_utils.rs
+++ b/src/grangers/grangers_utils.rs
@@ -3,7 +3,7 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 pub(crate) const VALIDSTRANDS: [&str; 2] = ["+", "-"];
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum FileFormat {
     GTF,
     GFF,
@@ -17,8 +17,8 @@ pub enum FileFormat {
 impl FileFormat {
     pub fn get_essential(&self) -> &[&str] {
         match self {
-            FileFormat::GTF => GTFESSENTIALATTRIBUTES.as_ref(),
-            FileFormat::GFF => GFFESSENTIALATTRIBUTES.as_ref(),
+            FileFormat::GTF => GXFESSENTIALATTRIBUTES.as_ref(),
+            FileFormat::GFF => GXFESSENTIALATTRIBUTES.as_ref(),
             _ => &[],
         }
     }
@@ -60,18 +60,20 @@ impl std::fmt::Display for FileFormat {
     }
 }
 
-pub const GTFESSENTIALATTRIBUTES: [&str; 4] = ["gene_id", "transcript_id", "gene_name", "exon_number"];
-pub const GFFESSENTIALATTRIBUTES: [&str; 5] = ["ID", "gene_id", "gene_name", "transcript_id", "exon_number"];
-// pub const FIELDS: [&str; 8] = [
-//     "seqid",
-//     "source",
-//     "feature_type",
-//     "start",
-//     "end",
-//     "score",
-//     "strand",
-//     "phase",
-// ];
+pub(crate) const GXFESSENTIALATTRIBUTES: [&str; 4] =
+    ["gene_id", "gene_name",  "transcript_id","exon_number"];
+
+pub(crate) const GXFFIELDS: [&str; 8] = [
+    "seqname",
+    "source",
+    "feature_type",
+    "start",
+    "end",
+    "score",
+    "strand",
+    "phase",
+];
+
 /// traverse the given file to get the number of lines in the file
 pub fn _file_line_count<T: AsRef<Path>>(file_path: T) -> anyhow::Result<usize> {
     let reader = BufReader::new(File::open(file_path)?);

--- a/src/grangers/grangers_utils.rs
+++ b/src/grangers/grangers_utils.rs
@@ -10,7 +10,7 @@ pub enum FileFormat {
     SAM,
     BAM,
     FASTA,
-    FASTQ
+    FASTQ,
 }
 
 impl FileFormat {
@@ -124,7 +124,6 @@ pub fn is_gzipped<T: BufRead>(reader: &mut T) -> std::io::Result<bool> {
     }
 }
 
-
 #[derive(Clone, Copy)]
 /// This enum is used for specifying the interval type of the input ranges.\
 /// Each variant takes a `i64` to represent the coordinate system.\
@@ -175,4 +174,3 @@ impl IntervalType {
         }
     }
 }
-

--- a/src/grangers/grangers_utils.rs
+++ b/src/grangers/grangers_utils.rs
@@ -174,3 +174,21 @@ impl IntervalType {
         }
     }
 }
+
+pub fn check_col(df: & polars::prelude::DataFrame, col: Option<&str>) -> anyhow::Result<String> {
+    let col_name = if let Some(col) = col {
+        if df.column(col)?.null_count() > 0 {
+            anyhow::bail!(
+                "The gene ID column {} contains null values. Cannot proceed.",
+                col
+            );
+        } else {
+            col
+        }
+    } else {
+        anyhow::bail!("The gene ID column is not defined in the Grangers struct. Cannot extract transcript sequences.")
+    };
+    Ok(col_name.to_string())
+
+}
+

--- a/src/grangers/grangers_utils.rs
+++ b/src/grangers/grangers_utils.rs
@@ -1,6 +1,11 @@
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
+use tracing::warn;
+
+use crate::options::FieldColumns;
+
+pub(crate) const VALIDSTRANDS: [&str;2] = ["+", "-"];
 
 #[derive(Copy, Clone)]
 pub enum FileFormat {
@@ -173,22 +178,5 @@ impl IntervalType {
             IntervalType::Exclusive(c) => -1 + 1 - c,
         }
     }
-}
-
-pub fn check_col(df: & polars::prelude::DataFrame, col: Option<&str>) -> anyhow::Result<String> {
-    let col_name = if let Some(col) = col {
-        if df.column(col)?.null_count() > 0 {
-            anyhow::bail!(
-                "The gene ID column {} contains null values. Cannot proceed.",
-                col
-            );
-        } else {
-            col
-        }
-    } else {
-        anyhow::bail!("The gene ID column is not defined in the Grangers struct. Cannot extract transcript sequences.")
-    };
-    Ok(col_name.to_string())
-
 }
 

--- a/src/grangers/grangers_utils.rs
+++ b/src/grangers/grangers_utils.rs
@@ -123,3 +123,56 @@ pub fn is_gzipped<T: BufRead>(reader: &mut T) -> std::io::Result<bool> {
         Ok(false)
     }
 }
+
+
+#[derive(Clone, Copy)]
+/// This enum is used for specifying the interval type of the input ranges.\
+/// Each variant takes a `i64` to represent the coordinate system.\
+/// For example, `Inclusive(1)` means 1-based [start,end]. This is also the format used in Grangers.\
+pub enum IntervalType {
+    /// Inclusive interval, e.g. [start, end]. GTF and GFF use this.
+    Inclusive(i64),
+    /// Exclusive interval, e.g. (start, end). VCF uses this.
+    Exclusive(i64),
+    /// Left inclusive, right exclusive, e.g. [start, end).
+    LeftInclusive(i64),
+    /// Left exclusive, right inclusive, e.g. (start, end]. BED uses this.
+    RightInclusive(i64),
+}
+
+impl Default for IntervalType {
+    fn default() -> Self {
+        IntervalType::Inclusive(1)
+    }
+}
+
+impl IntervalType {
+    pub fn from<T: ToString>(file_type: T) -> Self {
+        match file_type.to_string().to_lowercase().as_str() {
+            "gtf" | "gff" | "bam" | "sam" => IntervalType::Inclusive(1),
+            "bed" => IntervalType::RightInclusive(0),
+            _ => panic!("The file type is not supported"),
+        }
+    }
+    pub fn start_offset(&self) -> i64 {
+        // 1 - c is for coordinate
+        // the other 1 is for exclusive
+        match self {
+            IntervalType::Inclusive(c) => 1 - c,
+            IntervalType::LeftInclusive(c) => 1 - c,
+            IntervalType::RightInclusive(c) => 1 + 1 - c,
+            IntervalType::Exclusive(c) => 1 + 1 - c,
+        }
+    }
+    pub fn end_offset(&self) -> i64 {
+        // 1 - c is for coordinate
+        // -1 is for exclusive
+        match self {
+            IntervalType::Inclusive(c) => 1 - c,
+            IntervalType::LeftInclusive(c) => -1 + 1 - c,
+            IntervalType::RightInclusive(c) => 1 - c,
+            IntervalType::Exclusive(c) => -1 + 1 - c,
+        }
+    }
+}
+

--- a/src/grangers/options.rs
+++ b/src/grangers/options.rs
@@ -1,0 +1,140 @@
+use std::collections::HashSet;
+use tracing::{warn};
+use anyhow::{bail};
+
+#[derive(Clone)]
+pub struct IntronsOptions {
+    /// The representitive name of exon feature in the type_col
+    pub exon_name: String,
+    /// The column name of the feature_type column.
+    pub type_col: String,
+}
+
+impl Default for IntronsOptions {
+    fn default() -> Self {
+        Self {
+            exon_name: "exon".to_string(),
+            type_col: "feature_type".to_string(),
+        }
+    }
+}
+
+impl IntronsOptions {
+    pub fn new<T: ToString>(exon_name: T, type_col: T) -> Self {
+        Self {
+            exon_name: exon_name.to_string(),
+            type_col: type_col.to_string(),
+        }
+    }
+}
+
+
+#[derive(Copy, Clone)]
+pub struct FlankOptions {
+    pub start: bool,
+    pub both: bool,
+    pub ignore_strand: bool,
+}
+
+impl Default for FlankOptions {
+    fn default() -> FlankOptions {
+        FlankOptions {
+            start: true,
+            both: false,
+            ignore_strand: false,
+        }
+    }
+}
+
+impl FlankOptions {
+    pub fn new(start: bool, both: bool, ignore_strand: bool) -> FlankOptions {
+        FlankOptions {
+            start,
+            both,
+            ignore_strand,
+        }
+    }
+}
+
+/// Options used for the merge function
+/// - by: a vector of string representing which column(s) to merge by. Each string should be a valid column name.
+/// - slack: the minimum gap between two features to be merged. It should be a positive integer.
+/// - output_count: whether to output the count of ranges of the merged features.
+pub struct MergeOptions {
+    pub by: Vec<String>,
+    pub slack: i64,
+    pub ignore_strand: bool,
+}
+
+impl Default for MergeOptions {
+    fn default() -> MergeOptions {
+        MergeOptions {
+            by: vec![String::from("seqnames"), String::from("strand")],
+            slack: 1,
+            ignore_strand: false,
+        }
+    }
+}
+
+impl MergeOptions {
+    pub fn new<T: ToString>(
+        by: Vec<T>,
+        ignore_strand: bool,
+        slack: i64,
+    ) -> anyhow::Result<MergeOptions> {
+        // avoid duplicated columns
+        let mut by_hash: HashSet<String> = by.into_iter().map(|n| n.to_string()).collect();
+
+        if slack < 1 {
+            warn!("It usually doen't make sense to set a non-positive slack.")
+        }
+
+        if by_hash.take(&String::from("start")).is_some()
+            | by_hash.take(&String::from("end")).is_some()
+        {
+            bail!("The provided `by` vector cannot contain the start or end column")
+        };
+
+        if ignore_strand {
+            if by_hash.take(&String::from("strand")).is_some() {
+                warn!("Remove `strand` from the provided `by` vector as the ignored_strand flag is set.")
+            }
+        } else {
+            by_hash.insert(String::from("strand"));
+        }
+
+        // add chromosome name and strand if needed
+        if by_hash.insert(String::from("seqnames")) {
+            warn!("Added `seqnames` to the `by` vector as it is required.")
+        };
+
+        Ok(MergeOptions {
+            by: by_hash.into_iter().collect(),
+            slack,
+            ignore_strand,
+        })
+    }
+}
+
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ExtendOption {
+    /// Extend the feature to the start
+    Start,
+    /// Extend the feature to the end
+    End,
+    /// Extend the feature to both sides
+    Both,
+}
+
+pub struct GetSequenceOptions {
+
+}
+
+/// Options used for dealing with out-of-boundary features
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum OOBOption {
+    Truncate,
+    Skip,
+}
+

--- a/src/grangers/options.rs
+++ b/src/grangers/options.rs
@@ -50,8 +50,6 @@ impl Default for MergeOptions {
     }
 }
 
-
-
 impl MergeOptions {
     pub fn new<T: AsRef<str>>(
         by: &[T],
@@ -90,7 +88,6 @@ impl MergeOptions {
             ignore_strand,
         })
     }
-
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -233,7 +230,7 @@ impl Default for FieldColumns {
 }
 
 impl FieldColumns {
-    pub fn optional_fields(&self) -> [Option<&str>;8] {
+    pub fn optional_fields(&self) -> [Option<&str>; 8] {
         [
             self.source(),
             self.feature_type(),
@@ -245,13 +242,8 @@ impl FieldColumns {
             self.exon_number(),
         ]
     }
-    pub fn essential_fields(&self) -> [&str;4] {
-        [
-            self.seqname(),
-            self.start(),
-            self.end(),
-            self.strand(),
-        ]
+    pub fn essential_fields(&self) -> [&str; 4] {
+        [self.seqname(), self.start(), self.end(), self.strand()]
     }
     /// Validate itself according to a provided dataframe.
     /// If everything is Ok, return true, else, return false.
@@ -336,7 +328,7 @@ impl FieldColumns {
                 }
             }
         }
-        
+
         if let Some(s) = self.transcript_id() {
             if df.column(s).is_err() {
                 is_valid = false;
@@ -361,13 +353,17 @@ impl FieldColumns {
                 }
             }
         }
-        
+
         if !is_valid & is_bail {
-            bail!("The FieldColumns is not valid; Please try fix it by calling FieldColumns::fix().")
+            bail!(
+                "The FieldColumns is not valid; Please try fix it by calling FieldColumns::fix()."
+            )
         }
 
         if !is_valid & is_warn {
-            warn!("The FieldColumns is not valid; Please try fix it by calling FieldColumns::fix().")
+            warn!(
+                "The FieldColumns is not valid; Please try fix it by calling FieldColumns::fix()."
+            )
         }
 
         Ok(is_valid)
@@ -377,7 +373,10 @@ impl FieldColumns {
         // try fix required fields
         if df.column(self.seqname()).is_err() {
             if is_warn {
-                warn!("cannot find the specified seqname column {} in the dataframe; try to fix", self.seqname());
+                warn!(
+                    "cannot find the specified seqname column {} in the dataframe; try to fix",
+                    self.seqname()
+                );
             }
             if df.column("seqname").is_ok() {
                 self.seqname = "seqname".to_string();
@@ -387,7 +386,10 @@ impl FieldColumns {
         }
         if df.column(self.start()).is_err() {
             if is_warn {
-                warn!("cannot find the specified start column {} in the dataframe; try to fix", self.start());
+                warn!(
+                    "cannot find the specified start column {} in the dataframe; try to fix",
+                    self.start()
+                );
             }
             if df.column("start").is_ok() {
                 self.start = "start".to_string();
@@ -397,7 +399,10 @@ impl FieldColumns {
         }
         if df.column(self.end()).is_err() {
             if is_warn {
-                warn!("cannot find the specified end column {} in the dataframe; try to fix", self.end());
+                warn!(
+                    "cannot find the specified end column {} in the dataframe; try to fix",
+                    self.end()
+                );
             }
             if df.column("end").is_ok() {
                 self.end = "end".to_string();
@@ -407,7 +412,10 @@ impl FieldColumns {
         }
         if df.column(self.strand()).is_err() {
             if is_warn {
-                warn!("cannot find the specified strand column {} in the dataframe; try to fix", self.strand());
+                warn!(
+                    "cannot find the specified strand column {} in the dataframe; try to fix",
+                    self.strand()
+                );
             }
             if df.column("strand").is_ok() {
                 self.strand = "strand".to_string();
@@ -420,7 +428,10 @@ impl FieldColumns {
         if let Some(s) = self.source() {
             if df.column(s).is_err() {
                 if is_warn {
-                    warn!("cannot find the specified source column {} in the dataframe; try to fix", s);
+                    warn!(
+                        "cannot find the specified source column {} in the dataframe; try to fix",
+                        s
+                    );
                 }
                 self.source = if df.column("source").is_ok() {
                     Some("source".to_string())
@@ -444,7 +455,10 @@ impl FieldColumns {
         if let Some(s) = self.score() {
             if df.column(s).is_err() {
                 if is_warn {
-                    warn!("cannot find the specified score column {} in the dataframe; try to fix", s);
+                    warn!(
+                        "cannot find the specified score column {} in the dataframe; try to fix",
+                        s
+                    );
                 }
                 self.score = if df.column("score").is_ok() {
                     Some("score".to_string())
@@ -456,7 +470,10 @@ impl FieldColumns {
         if let Some(s) = self.phase() {
             if df.column(s).is_err() {
                 if is_warn {
-                    warn!("cannot find the specified phase column {} in the dataframe; try to fix", s);
+                    warn!(
+                        "cannot find the specified phase column {} in the dataframe; try to fix",
+                        s
+                    );
                 }
                 self.phase = if df.column("phase").is_ok() {
                     Some("phase".to_string())
@@ -468,7 +485,10 @@ impl FieldColumns {
         if let Some(s) = self.gene_id() {
             if df.column(s).is_err() {
                 if is_warn {
-                    warn!("cannot find the specified gene_id column {} in the dataframe; try to fix", s);
+                    warn!(
+                        "cannot find the specified gene_id column {} in the dataframe; try to fix",
+                        s
+                    );
                 }
                 self.gene_id = if df.column("gene_id").is_ok() {
                     Some("gene_id".to_string())
@@ -492,7 +512,10 @@ impl FieldColumns {
         if let Some(s) = self.exon_id() {
             if df.column(s).is_err() {
                 if is_warn {
-                    warn!("cannot find the specified exon_id column {} in the dataframe; try to fix", s);
+                    warn!(
+                        "cannot find the specified exon_id column {} in the dataframe; try to fix",
+                        s
+                    );
                 }
                 self.exon_id = if df.column("exon_id").is_ok() {
                     Some("exon_id".to_string())
@@ -513,7 +536,7 @@ impl FieldColumns {
                 }
             }
         }
-        
+
         Ok(())
     }
 
@@ -531,12 +554,14 @@ impl FieldColumns {
             "transcript_id" => self.transcript_id(),
             "exon_id" => self.exon_id(),
             "exon_number" => self.exon_number(),
-            _ => {
-                None
-            }
+            _ => None,
         }
     }
-    pub fn field_checked<T: AsRef<str>>(&self, field: T, is_bail: bool) -> anyhow::Result<Option<&str>> {
+    pub fn field_checked<T: AsRef<str>>(
+        &self,
+        field: T,
+        is_bail: bool,
+    ) -> anyhow::Result<Option<&str>> {
         match field.as_ref() {
             "seqname" => Ok(Some(self.seqname.as_str())),
             "source" => Ok(self.source()),

--- a/src/grangers/options.rs
+++ b/src/grangers/options.rs
@@ -152,7 +152,7 @@ pub struct FieldColumns {
     /// The column name of the transcript ID column, usually it is called "transcript_id".
     pub transcript_id: Option<String>,
     // The column name of the exon ID column, usually it is called "exon_id".
-    pub exon_id: Option<String>,
+    // pub exon_id: Option<String>,
     /// The column name of the exon number (order) column, usually it is called "exon_number".
     /// This column is used to sort the exons of a transcript.
     /// If this column is missing, the exons will be sorted by their start positions.
@@ -200,10 +200,10 @@ impl FieldColumns {
     pub fn transcript_id(&self) -> Option<&str> {
         self.transcript_id.as_deref()
     }
-    /// get a reference to the exon_id field
-    pub fn exon_id(&self) -> Option<&str> {
-        self.exon_id.as_deref()
-    }
+    // get a reference to the exon_id field
+    // pub fn exon_id(&self) -> Option<&str> {
+    //     self.exon_id.as_deref()
+    // }
     /// get a reference to the exon_number field
     pub fn exon_number(&self) -> Option<&str> {
         self.exon_number.as_deref()
@@ -223,14 +223,14 @@ impl Default for FieldColumns {
             phase: Some("phase".to_string()),
             gene_id: Some("gene_id".to_string()),
             transcript_id: Some("transcript_id".to_string()),
-            exon_id: Some("exon_id".to_string()),
+            // exon_id: Some("exon_id".to_string()),
             exon_number: Some("exon_number".to_string()),
         }
     }
 }
 
 impl FieldColumns {
-    pub fn optional_fields(&self) -> [Option<&str>; 8] {
+    pub fn optional_fields(&self) -> [Option<&str>; 7] {
         [
             self.source(),
             self.feature_type(),
@@ -238,7 +238,7 @@ impl FieldColumns {
             self.phase(),
             self.gene_id(),
             self.transcript_id(),
-            self.exon_id(),
+            // self.exon_id(),
             self.exon_number(),
         ]
     }
@@ -337,14 +337,14 @@ impl FieldColumns {
                 }
             }
         }
-        if let Some(s) = self.exon_id() {
-            if df.column(s).is_err() {
-                is_valid = false;
-                if is_warn {
-                    warn!("The provided exon_id column {} is not found in the dataframe; It will be ignored", s)
-                }
-            }
-        }
+        // if let Some(s) = self.exon_id() {
+        //     if df.column(s).is_err() {
+        //         is_valid = false;
+        //         if is_warn {
+        //             warn!("The provided exon_id column {} is not found in the dataframe; It will be ignored", s)
+        //         }
+        //     }
+        // }
         if let Some(s) = self.exon_number() {
             if df.column(s).is_err() {
                 is_valid = false;
@@ -509,21 +509,21 @@ impl FieldColumns {
                 }
             }
         }
-        if let Some(s) = self.exon_id() {
-            if df.column(s).is_err() {
-                if is_warn {
-                    warn!(
-                        "cannot find the specified exon_id column {} in the dataframe; try to fix",
-                        s
-                    );
-                }
-                self.exon_id = if df.column("exon_id").is_ok() {
-                    Some("exon_id".to_string())
-                } else {
-                    None
-                }
-            }
-        }
+        // if let Some(s) = self.exon_id() {
+        //     if df.column(s).is_err() {
+        //         if is_warn {
+        //             warn!(
+        //                 "cannot find the specified exon_id column {} in the dataframe; try to fix",
+        //                 s
+        //             );
+        //         }
+        //         self.exon_id = if df.column("exon_id").is_ok() {
+        //             Some("exon_id".to_string())
+        //         } else {
+        //             None
+        //         }
+        //     }
+        // }
         if let Some(s) = self.exon_number() {
             if df.column(s).is_err() {
                 if is_warn {
@@ -552,7 +552,7 @@ impl FieldColumns {
             "phase" => self.phase(),
             "gene_id" => self.gene_id(),
             "transcript_id" => self.transcript_id(),
-            "exon_id" => self.exon_id(),
+            // "exon_id" => self.exon_id(),
             "exon_number" => self.exon_number(),
             _ => None,
         }
@@ -573,7 +573,7 @@ impl FieldColumns {
             "phase" => Ok(self.phase()),
             "gene_id" => Ok(self.gene_id()),
             "transcript_id" => Ok(self.transcript_id()),
-            "exon_id" => Ok(self.exon_id()),
+            // "exon_id" => Ok(self.exon_id()),
             "exon_number" => Ok(self.exon_number()),
             _ => {
                 if is_bail {

--- a/src/grangers/options.rs
+++ b/src/grangers/options.rs
@@ -1,33 +1,7 @@
+use anyhow::bail;
+use polars::prelude::DataFrame;
 use std::collections::HashSet;
-use tracing::{warn};
-use anyhow::{bail};
-
-#[derive(Clone)]
-pub struct IntronsOptions {
-    /// The representitive name of exon feature in the type_col
-    pub exon_name: String,
-    /// The column name of the feature_type column.
-    pub type_col: String,
-}
-
-impl Default for IntronsOptions {
-    fn default() -> Self {
-        Self {
-            exon_name: "exon".to_string(),
-            type_col: "feature_type".to_string(),
-        }
-    }
-}
-
-impl IntronsOptions {
-    pub fn new<T: ToString>(exon_name: T, type_col: T) -> Self {
-        Self {
-            exon_name: exon_name.to_string(),
-            type_col: type_col.to_string(),
-        }
-    }
-}
-
+use tracing::warn;
 
 #[derive(Copy, Clone)]
 pub struct FlankOptions {
@@ -69,7 +43,7 @@ pub struct MergeOptions {
 impl Default for MergeOptions {
     fn default() -> MergeOptions {
         MergeOptions {
-            by: vec![String::from("seqnames"), String::from("strand")],
+            by: vec![String::from("seqname"), String::from("strand")],
             slack: 1,
             ignore_strand: false,
         }
@@ -77,13 +51,13 @@ impl Default for MergeOptions {
 }
 
 impl MergeOptions {
-    pub fn new<T: ToString>(
-        by: Vec<T>,
+    pub fn new<T: AsRef<str>>(
+        by: &[T],
         ignore_strand: bool,
         slack: i64,
     ) -> anyhow::Result<MergeOptions> {
         // avoid duplicated columns
-        let mut by_hash: HashSet<String> = by.into_iter().map(|n| n.to_string()).collect();
+        let mut by_hash: HashSet<String> = by.into_iter().map(|n| n.as_ref().to_string()).collect();
 
         if slack < 1 {
             warn!("It usually doen't make sense to set a non-positive slack.")
@@ -104,8 +78,8 @@ impl MergeOptions {
         }
 
         // add chromosome name and strand if needed
-        if by_hash.insert(String::from("seqnames")) {
-            warn!("Added `seqnames` to the `by` vector as it is required.")
+        if by_hash.insert(String::from("seqname")) {
+            warn!("Added `seqname` to the `by` vector as it is required.")
         };
 
         Ok(MergeOptions {
@@ -115,7 +89,6 @@ impl MergeOptions {
         })
     }
 }
-
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum ExtendOption {
@@ -127,9 +100,7 @@ pub enum ExtendOption {
     Both,
 }
 
-pub struct GetSequenceOptions {
-
-}
+pub struct GetSequenceOptions {}
 
 /// Options used for dealing with out-of-boundary features
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -138,3 +109,309 @@ pub enum OOBOption {
     Skip,
 }
 
+/// The name of columns used to store the information of features.
+/// It is designed according to the GTF/GFF format.
+/// https://useast.ensembl.org/info/website/upload/gff.html
+/// The default values are the column names used in GTF/GFF files.
+/// This will be used in almost all Grangers methods.
+#[derive(Clone, PartialEq, Eq)]
+pub struct FieldColumns {
+    /// the name of the reference sequence column, usually it is called "seqname".\
+    /// This corresponds to the first column in a GTF/GFF file.\
+    /// This field is required, and the corresponding column should not contain missing values (nulls).\
+    /// You can drop all rows with missing values in this column by calling `df.drop_nulls(Some(["seqname"]))`.
+    pub seqname: String,
+    /// the name of the source column, usually it is called "source".
+    /// This is the second column in a GTF/GFF file. It records the source (HAVANA, ENSEMBL, etc) of the feature.
+    pub source: Option<String>,
+    /// The name of the feature type column whose values should be "gene", "transcript" and "exon", etc.
+    /// This should be the third column in a GTF/GFF file.
+    /// This field is required for transcriptome related methods, like `introns()`, `get_transcript_sequeneces()`, etc.
+    pub feature_type: Option<String>,
+    /// The column name of the start position column, usually it is called "start".
+    /// This is the fourth column in a GTF/GFF file.
+    /// This field is required, and the corresponding column should not contain missing values (nulls).
+    pub start: String,
+    /// The column name of the end position column, usually it is called "end".
+    /// This is the fifth column in a GTF/GFF file.
+    /// This field is required, and the corresponding column should not contain missing values (nulls).
+    pub end: String,
+    /// The column name of the score column, usually it is called "score".
+    pub score: Option<String>,
+    /// The column name of the strand column, usually it is called "strand".
+    /// This is the seventh column in a GTF/GFF file.\
+    /// This field is required, and the corresponding column should not contain missing values (nulls) for calling most Grangers methods.\
+    /// If this field is missing, you can add one by calling `df.add_column("strand", vec!['.'; df.height()])`.\
+    /// If it contains missing values, you can fill them by calling `df.fill_none("strand", '.')`.
+    pub strand: String,
+    /// The column name of the phase column, usually it is called "frame" or "phase".
+    /// This is the eighth column in a GTF/GFF file.
+    pub phase: Option<String>,
+    /// The column name of the gene ID column, usually it is called "gene_id".
+    pub gene_id: Option<String>,
+    /// The column name of the transcript ID column, usually it is called "transcript_id".
+    pub transcript_id: Option<String>,
+    // The column name of the exon ID column, usually it is called "exon_id".
+    pub exon_id: Option<String>,
+    /// The column name of the exon number (order) column, usually it is called "exon_number".
+    /// This column is used to sort the exons of a transcript.
+    /// If this column is missing, the exons will be sorted by their start positions.
+    pub exon_number: Option<String>,
+}
+
+impl FieldColumns {
+    /// get a reference to the seqname field
+    pub fn seqname(&self) -> &str {
+        self.seqname.as_str()
+    }
+    /// get a reference to the source field
+    pub fn source(&self) -> Option<&str> {
+        self.source.as_deref()
+    }
+    /// get a reference to the feature_type field
+    pub fn feature_type(&self) -> Option<&str> {
+        self.feature_type.as_deref()
+    }
+    /// get a reference to the start field
+    pub fn start(&self) -> &str {
+        self.start.as_str()
+    }
+    /// get a reference to the end field
+    pub fn end(&self) -> &str {
+        self.end.as_str()
+    }
+    /// get a reference to the score field
+    pub fn score(&self) -> Option<&str> {
+        self.score.as_deref()
+    }
+    /// get a reference to the strand field
+    pub fn strand(&self) -> &str {
+        self.strand.as_str()
+    }
+    /// get a reference to the phase field
+    pub fn phase(&self) -> Option<&str> {
+        self.phase.as_deref()
+    }
+    /// get a reference to the gene_id field
+    pub fn gene_id(&self) -> Option<&str> {
+        self.gene_id.as_deref()
+    }
+    /// get a reference to the transcript_id field
+    pub fn transcript_id(&self) -> Option<&str> {
+        self.transcript_id.as_deref()
+    }
+    /// get a reference to the exon_id field
+    pub fn exon_id(&self) -> Option<&str> {
+        self.exon_id.as_deref()
+    }
+    /// get a reference to the exon_number field
+    pub fn exon_number(&self) -> Option<&str> {
+        self.exon_number.as_deref()
+    }
+}
+
+impl Default for FieldColumns {
+    fn default() -> Self {
+        Self {
+            seqname: "seqname".to_string(),
+            source: Some("source".to_string()),
+            feature_type: Some("feature_type".to_string()),
+            start: "start".to_string(),
+            end: "end".to_string(),
+            score: Some("score".to_string()),
+            strand: "strand".to_string(),
+            phase: Some("phase".to_string()),
+            gene_id: Some("gene_id".to_string()),
+            transcript_id: Some("transcript_id".to_string()),
+            exon_id: Some("exon_id".to_string()),
+            exon_number: Some("exon_number".to_string()),
+        }
+    }
+}
+
+impl FieldColumns {
+    /// create a new TxColumns struct.
+    pub fn new<T: Into<String>>(
+        seqname: T,
+        source: Option<T>,
+        feature_type: Option<T>,
+        start: T,
+        end: T,
+        score: Option<T>,
+        strand: T,
+        phase: Option<T>,
+        gene_id: Option<T>,
+        transcript_id: Option<T>,
+        exon_id: Option<T>,
+        exon_number: Option<T>,
+    ) -> Self {
+        Self {
+            seqname: seqname.into(),
+            source: source.map(|v| v.into()),
+            feature_type: feature_type.map(|v| v.into()),
+            start: start.into(),
+            end: end.into(),
+            score: score.map(|v| v.into()),
+            strand: strand.into(),
+            phase: phase.map(|v| v.into()),
+            gene_id: gene_id.map(|v| v.into()),
+            transcript_id: transcript_id.map(|v| v.into()),
+            exon_id: exon_id.map(|v| v.into()),
+            exon_number: exon_number.map(|v| v.into()),
+        }
+    }
+
+    /// validate the provided dataframe.
+    /// If everything is Ok, return Ok(None)
+    /// If some required fields are missing, return an error.
+    /// if some optional fields are missing, return a FieldColumns struct with these missing fields set as None.
+    /// If not, return a FieldColumns struct with all missing field as None.
+    pub fn validate(&self, df: &DataFrame, complain: bool) -> anyhow::Result<Option<Self>> {
+        let mut fc = self.clone();
+        // check required fields
+        if df.column(fc.seqname.as_str()).is_err()
+            || df.column(fc.seqname.as_str())?.null_count() > 0
+        {
+            bail!(
+                "The dataframe either does not contain the specified seqname column {} or this column contains missing value; Cannot proceed",
+                fc.seqname
+            );
+        }
+        if df.column(fc.start.as_str()).is_err() || df.column(fc.start.as_str())?.null_count() > 0 {
+            bail!(
+                "The dataframe does not contain the specified start column {} or this column contains missing value; Cannot proceed",
+                fc.start
+            );
+        }
+        if df.column(fc.end.as_str()).is_err() || df.column(fc.end.as_str())?.null_count() > 0 {
+            bail!(
+                "The dataframe does not contain the specified end column {} or this column contains missing value; Cannot proceed",
+                fc.end
+            );
+        }
+        if df.column(fc.strand.as_str()).is_err() {
+            bail!(
+                "The dataframe does not contain the specified strand column {}; Cannot proceed. You can add one by calling `df.add_column(\"strand\", vec!['.'; df.height()])`",
+                fc.strand
+            );
+        }
+
+        // check optional fields
+        if let Some(s) = fc.source.to_owned() {
+            if df.column(s.as_str()).is_err() {
+                fc.source = None;
+            }
+            if complain {
+                warn!("The provided source column {} is not found in the dataframe; It will be ignored", s)
+            }
+        }
+        if let Some(s) = fc.feature_type.to_owned() {
+            if df.column(s.as_str()).is_err() {
+                fc.feature_type = None;
+            }
+            if complain {
+                warn!("The provided feature_type column {} is not found in the dataframe; It will be ignored", s)
+            }
+        }
+        if let Some(s) = fc.score.to_owned() {
+            if df.column(s.as_str()).is_err() {
+                fc.score = None;
+            }
+            if complain {
+                warn!("The provided score column {} is not found in the dataframe; It will be ignored", s)
+            }
+        }
+        if let Some(s) = fc.phase.to_owned() {
+            if df.column(s.as_str()).is_err() {
+                fc.phase = None;
+            }
+            if complain {
+                warn!("The provided phase column {} is not found in the dataframe; It will be ignored", s)
+            }
+        }
+        if let Some(s) = fc.gene_id.to_owned() {
+            if df.column(s.as_str()).is_err() {
+                fc.gene_id = None;
+            }
+            if complain {
+                warn!("The provided gene_id column {} is not found in the dataframe; It will be ignored", s)
+            }
+        }
+        if let Some(s) = fc.transcript_id.to_owned() {
+            if df.column(s.as_str()).is_err() {
+                fc.transcript_id = None;
+            }
+            if complain {
+                warn!("The provided transcript_id column {} is not found in the dataframe; It will be ignored", s)
+            }
+        }
+        if let Some(s) = fc.exon_id.to_owned() {
+            if df.column(s.as_str()).is_err() {
+                fc.exon_id = None;
+            }
+            if complain {
+                warn!("The provided exon_id column {} is not found in the dataframe; It will be ignored", s)
+            }
+        }
+        if let Some(s) = fc.exon_number.to_owned() {
+            if df.column(s.as_str()).is_err() {
+                fc.exon_number = None;
+            }
+            if complain {
+                warn!("The provided exon_number column {} is not found in the dataframe; It will be ignored", s)
+            }
+        }
+        // if fc is not the same as self, it means that some optional fields are missing.
+        if &fc == self {
+            Ok(None)
+        } else {
+            Ok(Some(fc))
+        }
+    }
+
+    pub fn get_colname<T: AsRef<str>>(&self, field: T, complain: bool) -> Option<&str> {
+        match field.as_ref() {
+            "seqname" => Some(self.seqname.as_str()),
+            "source" => self.source(),
+            "feature_type" => self.feature_type(),
+            "start" => Some(self.start.as_str()),
+            "end" => Some(self.end.as_str()),
+            "score" => self.score(),
+            "strand" => Some(self.strand.as_str()),
+            "phase" => self.phase(),
+            "gene_id" => self.gene_id(),
+            "transcript_id" => self.transcript_id(),
+            "exon_id" => self.exon_id(),
+            "exon_number" => self.exon_number(),
+            _ => {
+                if complain {
+                    warn!(
+                        "The provided field {} is not a valid field name; It will be ignored",
+                        field.as_ref()
+                    );
+                }
+                None
+            }
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub enum IntronsBy {
+    /// find exons of each gene and (deduplicate if needed)
+    Gene,
+    /// find exons of each transcript (no deduplication)
+    Transcript,
+    /// find exons according to a custom column
+    Other(String),
+}
+
+impl AsRef<str> for IntronsBy {
+    fn as_ref(&self) -> &str {
+        match self {
+            IntronsBy::Gene => "gene_id",
+            IntronsBy::Transcript => "transcript_id",
+            IntronsBy::Other(s) => s.as_str(),
+        }
+    }
+}

--- a/src/grangers/options.rs
+++ b/src/grangers/options.rs
@@ -33,7 +33,7 @@ impl FlankOptions {
 /// Options used for the merge function
 /// - by: a vector of string representing which column(s) to merge by. Each string should be a valid column name.
 /// - slack: the minimum gap between two features to be merged. It should be a positive integer.
-/// - output_count: whether to output the count of ranges of the merged features.
+/// - ignore_strand: whether to ignore the strand information when merging.
 pub struct MergeOptions {
     pub by: Vec<String>,
     pub slack: i64,
@@ -57,7 +57,7 @@ impl MergeOptions {
         slack: i64,
     ) -> anyhow::Result<MergeOptions> {
         // avoid duplicated columns
-        let mut by_hash: HashSet<String> = by.into_iter().map(|n| n.as_ref().to_string()).collect();
+        let mut by_hash: HashSet<String> = by.iter().map(|n| n.as_ref().to_string()).collect();
 
         if slack < 1 {
             warn!("It usually doen't make sense to set a non-positive slack.")
@@ -229,37 +229,39 @@ impl Default for FieldColumns {
     }
 }
 
-impl FieldColumns {
-    /// create a new TxColumns struct.
-    pub fn new<T: Into<String>>(
-        seqname: T,
-        source: Option<T>,
-        feature_type: Option<T>,
-        start: T,
-        end: T,
-        score: Option<T>,
-        strand: T,
-        phase: Option<T>,
-        gene_id: Option<T>,
-        transcript_id: Option<T>,
-        exon_id: Option<T>,
-        exon_number: Option<T>,
-    ) -> Self {
-        Self {
-            seqname: seqname.into(),
-            source: source.map(|v| v.into()),
-            feature_type: feature_type.map(|v| v.into()),
-            start: start.into(),
-            end: end.into(),
-            score: score.map(|v| v.into()),
-            strand: strand.into(),
-            phase: phase.map(|v| v.into()),
-            gene_id: gene_id.map(|v| v.into()),
-            transcript_id: transcript_id.map(|v| v.into()),
-            exon_id: exon_id.map(|v| v.into()),
-            exon_number: exon_number.map(|v| v.into()),
-        }
-    }
+impl FieldColumns { 
+    // TODO: this function causes too many parameters warning.
+    // we should either remove it or find a way to solve it
+    // /// create a new TxColumns struct.
+    // pub fn new<T: Into<String>>(
+    //     seqname: T,
+    //     source: Option<T>,
+    //     feature_type: Option<T>,
+    //     start: T,
+    //     end: T,
+    //     score: Option<T>,
+    //     strand: T,
+    //     phase: Option<T>,
+    //     gene_id: Option<T>,
+    //     transcript_id: Option<T>,
+    //     exon_id: Option<T>,
+    //     exon_number: Option<T>,
+    // ) -> Self {
+    //     Self {
+    //         seqname: seqname.into(),
+    //         source: source.map(|v| v.into()),
+    //         feature_type: feature_type.map(|v| v.into()),
+    //         start: start.into(),
+    //         end: end.into(),
+    //         score: score.map(|v| v.into()),
+    //         strand: strand.into(),
+    //         phase: phase.map(|v| v.into()),
+    //         gene_id: gene_id.map(|v| v.into()),
+    //         transcript_id: transcript_id.map(|v| v.into()),
+    //         exon_id: exon_id.map(|v| v.into()),
+    //         exon_number: exon_number.map(|v| v.into()),
+    //     }
+    // }
 
     /// validate the provided dataframe.
     /// If everything is Ok, return Ok(None)

--- a/src/grangers/reader/fasta.rs
+++ b/src/grangers/reader/fasta.rs
@@ -7,7 +7,7 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 #[derive(Clone)]
 pub struct SeqInfo {
-    seqnames: Vec<String>,
+    seqname: Vec<String>,
     seqlengths: Option<Vec<usize>>,
     is_circular: Option<Vec<bool>>,
     genome: Option<String>,
@@ -15,9 +15,9 @@ pub struct SeqInfo {
 }
 
 impl SeqInfo {
-    /// get the seqnames of the genome/reference set
-    pub fn seqnames(&self) -> &Vec<String> {
-        &self.seqnames
+    /// get the seqname of the genome/reference set
+    pub fn seqname(&self) -> &Vec<String> {
+        &self.seqname
     }
 
     /// get the seqlengths of the genome/reference set
@@ -40,33 +40,33 @@ impl SeqInfo {
         &self.extra
     }
 
-    /// set the seqnames of the genome/reference set
-    pub fn set_seqnames(&mut self, seqnames: Vec<String>) {
-        self.seqnames = seqnames;
+    /// set the seqname of the genome/reference set
+    pub fn set_seqnames(&mut self, seqname: Vec<String>) {
+        self.seqname = seqname;
     }
 
     pub fn new(
-        seqnames: Vec<String>,
+        seqname: Vec<String>,
         seqlengths: Option<Vec<usize>>,
         is_circular: Option<Vec<bool>>,
         genome: Option<String>,
         extra: Option<HashMap<String, Vec<String>>>,
     ) -> anyhow::Result<SeqInfo> {
         if let Some(v) = &seqlengths {
-            if equal_length(&seqnames, v) {
-                bail!("seqnames and seqlengths have different length; Could not create SeqInfo")
+            if equal_length(&seqname, v) {
+                bail!("seqname and seqlengths have different length; Could not create SeqInfo")
             }
         }
         if let Some(v) = &is_circular {
-            if equal_length(&seqnames, v) {
-                bail!("seqnames and is_circular have different length; Could not create SeqInfo")
+            if equal_length(&seqname, v) {
+                bail!("seqname and is_circular have different length; Could not create SeqInfo")
             }
         }
         if let Some(hm) = &extra {
             for (k, v) in hm.iter() {
-                if equal_length(&seqnames, v) {
+                if equal_length(&seqname, v) {
                     bail!(
-                        "seqnames and {} have different length; Could not create SeqInfo",
+                        "seqname and {} have different length; Could not create SeqInfo",
                         k
                     )
                 }
@@ -74,7 +74,7 @@ impl SeqInfo {
         }
 
         Ok(SeqInfo {
-            seqnames,
+            seqname,
             seqlengths,
             is_circular,
             genome,
@@ -83,12 +83,12 @@ impl SeqInfo {
     }
 
     /// This function parse a fasta file to get the seqinfo of the genome/reference set.
-    /// seqinfo can contain "seqnames", "seqlengths", "isCircular", "genome", and other extra string info
+    /// seqinfo can contain "seqname", "seqlengths", "isCircular", "genome", and other extra string info
     pub fn from_fasta<T: AsRef<Path>>(file_path: T) -> anyhow::Result<SeqInfo> {
         // get chromsize
-        let (seqnames, seqlengths) = get_chromsize(&file_path)?;
+        let (seqname, seqlengths) = get_chromsize(&file_path)?;
         let si = SeqInfo::new(
-            seqnames,
+            seqname,
             Some(seqlengths),
             None,
             Some(file_path.as_ref().to_string_lossy().to_string()),
@@ -97,8 +97,10 @@ impl SeqInfo {
         si
     }
 }
-/// traverses the given fasta file returns a tuple of seqnames and seqlengths
-pub fn build_fasta_reader<T: AsRef<Path>, R: BufRead>(file_path: T) -> anyhow::Result<fasta::Reader<BufReader<File>>> {
+/// traverses the given fasta file returns a tuple of seqname and seqlengths
+pub fn build_fasta_reader<T: AsRef<Path>, R: BufRead>(
+    file_path: T,
+) -> anyhow::Result<fasta::Reader<BufReader<File>>> {
     // create reader
     let reader: fasta::Reader<BufReader<File>> = File::open(file_path)
         .map(BufReader::new)
@@ -106,7 +108,7 @@ pub fn build_fasta_reader<T: AsRef<Path>, R: BufRead>(file_path: T) -> anyhow::R
     Ok(reader)
 }
 
-/// traverses the given fasta file returns a tuple of seqnames and seqlengths
+/// traverses the given fasta file returns a tuple of seqname and seqlengths
 pub fn get_chromsize<T: AsRef<Path>>(file_path: T) -> anyhow::Result<(Vec<String>, Vec<usize>)> {
     // create reader
     let mut reader = File::open(file_path)
@@ -121,12 +123,12 @@ fn _get_chromsize<T: BufRead>(
     rdr: &mut fasta::Reader<T>,
 ) -> anyhow::Result<(Vec<String>, Vec<usize>)> {
     // get chromsize
-    let mut seqnames: Vec<String> = Vec::new();
+    let mut seqname: Vec<String> = Vec::new();
     let mut seqlengths: Vec<usize> = Vec::new();
 
     for result in rdr.records() {
         let record = result?;
-        seqnames.push(
+        seqname.push(
             record
                 .name()
                 .split_once(' ')
@@ -137,7 +139,7 @@ fn _get_chromsize<T: BufRead>(
         seqlengths.push(record.sequence().len());
     }
 
-    Ok((seqnames, seqlengths))
+    Ok((seqname, seqlengths))
 }
 
 #[cfg(test)]

--- a/src/grangers/reader/fasta.rs
+++ b/src/grangers/reader/fasta.rs
@@ -97,6 +97,14 @@ impl SeqInfo {
         si
     }
 }
+/// traverses the given fasta file returns a tuple of seqnames and seqlengths
+pub fn build_fasta_reader<T: AsRef<Path>, R: BufRead>(file_path: T) -> anyhow::Result<fasta::Reader<BufReader<File>>> {
+    // create reader
+    let reader: fasta::Reader<BufReader<File>> = File::open(file_path)
+        .map(BufReader::new)
+        .map(fasta::Reader::new)?;
+    Ok(reader)
+}
 
 /// traverses the given fasta file returns a tuple of seqnames and seqlengths
 pub fn get_chromsize<T: AsRef<Path>>(file_path: T) -> anyhow::Result<(Vec<String>, Vec<usize>)> {

--- a/src/grangers/reader/gtf.rs
+++ b/src/grangers/reader/gtf.rs
@@ -378,7 +378,7 @@ mod tests {
                         tally,
                     } => {
                         assert!(
-                            file_type.get_essential() == &["gene_id", "gene_name", "transcript_id"]
+                            file_type == FileFormat::GTF
                         );
                         assert!(essential
                             .get("gene_id")
@@ -482,8 +482,8 @@ mod tests {
                         tally,
                     } => {
                         assert!(
-                            file_type.get_essential()
-                                == &["ID", "gene_id", "gene_name", "transcript_id"]
+                            file_type == FileFormat::GFF
+
                         );
                         assert!(essential
                             .get("gene_id")

--- a/src/grangers/reader/gtf.rs
+++ b/src/grangers/reader/gtf.rs
@@ -136,9 +136,7 @@ pub struct GStruct {
     pub strand: Vec<Option<String>>,
     pub phase: Vec<Option<String>>,
     pub attributes: Attributes,
-    pub misc: Option<
-        HashMap<String, Vec<String>>, // , polars::export::ahash::RandomState
-    >,
+    pub misc: Option<HashMap<String, Vec<String>>>,
 }
 
 // implement GTF reader
@@ -316,7 +314,6 @@ impl GStruct {
             attributes: Attributes::new(attribute_mode, file_type)?,
             misc: Some(HashMap::new()),
         };
-
         Ok(gr)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,9 @@ use std::time::{Duration, Instant};
 use tracing::info;
 use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*, EnvFilter};
 pub mod grangers;
+use crate::grangers::options::FieldColumns;
 // use crate::grangers::{FileFormat, FlankOptions};
-use crate::grangers::{Grangers, options, IntervalType};
+use crate::grangers::{options, Grangers, IntervalType};
 use peak_alloc::PeakAlloc;
 use polars::prelude::*;
 
@@ -13,116 +14,117 @@ use polars::prelude::*;
 static PEAK_ALLOC: PeakAlloc = PeakAlloc;
 
 fn main() -> anyhow::Result<()> {
-    // Check the `RUST_LOG` variable for the logger level and
-    // respect the value found there. If this environment
-    // variable is not set then set the logging level to
-    // INFO.
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(
-            EnvFilter::builder()
-                .with_default_directive(LevelFilter::INFO.into())
-                .from_env_lossy(),
-        )
-        .init();
+    // // Check the `RUST_LOG` variable for the logger level and
+    // // respect the value found there. If this environment
+    // // variable is not set then set the logging level to
+    // // INFO.
+    // tracing_subscriber::registry()
+    //     .with(fmt::layer())
+    //     .with(
+    //         EnvFilter::builder()
+    //             .with_default_directive(LevelFilter::INFO.into())
+    //             .from_env_lossy(),
+    //     )
+    //     .init();
 
-    let args: Vec<String> = env::args().collect();
-    let gtf_file = PathBuf::from(args.get(1).unwrap());
+    // let args: Vec<String> = env::args().collect();
+    // let gtf_file = PathBuf::from(args.get(1).unwrap());
 
-    // let _fasta_file = PathBuf::from(
-    //     "/mnt/scratch3/alevin_fry_submission/refs/refdata-gex-GRCh38-2020-A/fasta/genome.fa",
-    // );
+    // // let _fasta_file = PathBuf::from(
+    // //     "/mnt/scratch3/alevin_fry_submission/refs/refdata-gex-GRCh38-2020-A/fasta/genome.fa",
+    // // );
 
-    // println!("Start parsing GTF");
+    // // println!("Start parsing GTF");
+    // // let start = Instant::now();
+
+    // // let duration: Duration = start.elapsed();
+    // // println!("Parsed GTF in {:?}", duration);
+
     // let start = Instant::now();
-
+    // let mut gr = Grangers::from_gtf(gtf_file.as_path(), false)?;
     // let duration: Duration = start.elapsed();
-    // println!("Parsed GTF in {:?}", duration);
+    // info!("Built Grangers in {:?}", duration);
+    // info!("Grangers shape {:?}", gr.df().shape());
 
-    let start = Instant::now();
-    let mut gr = Grangers::from_gtf(gtf_file.as_path(), false)?;
-    let duration: Duration = start.elapsed();
-    info!("Built Grangers in {:?}", duration);
-    info!("Grangers shape {:?}", gr.df().shape());
+    // let mo = options::MergeOptions::new(&vec!["seqname", "gene_id", "transcript_id"], false, 1)?;
+    // let start = Instant::now();
+    // gr.merge(&mo)?;
+    // let duration: Duration = start.elapsed();
+    // info!("Merged overlapping ranges in {:?}", duration);
 
-    let mo = options::MergeOptions::new(vec!["seqnames", "gene_id", "transcript_id"], false, 1)?;
-    let start = Instant::now();
-    gr.merge(&mo)?;
-    let duration: Duration = start.elapsed();
-    info!("Merged overlapping ranges in {:?}", duration);
+    // let start = Instant::now();
+    // gr.flank(10, options::FlankOptions::default())?;
+    // let duration: Duration = start.elapsed();
+    // info!("Flanked ranges in {:?}", duration);
 
-    let start = Instant::now();
-    gr.flank(10, options::FlankOptions::default())?;
-    let duration: Duration = start.elapsed();
-    info!("Flanked ranges in {:?}", duration);
+    // let start = Instant::now();
+    // gr.introns(options::IntronsBy::Gene, None, true)?;
+    // let duration: Duration = start.elapsed();
+    // info!("Built intron's Grangers in {:?}", duration);
 
-    let start = Instant::now();
-    gr.introns("gene_id", options::IntronsOptions::default())?;
-    let duration: Duration = start.elapsed();
-    info!("Built intron's Grangers in {:?}", duration);
+    // let start = Instant::now();
+    // gr.extend(10, &options::ExtendOption::Both, false)?;
+    // let duration: Duration = start.elapsed();
+    // info!("Extended ranges in {:?}", duration);
 
-    let start = Instant::now();
-    gr.extend(10, &options::ExtendOption::Both, false)?;
-    let duration: Duration = start.elapsed();
-    info!("Extended ranges in {:?}", duration);
+    // let start = Instant::now();
+    // gr.build_lapper(&mo.by)?;
+    // let duration: Duration = start.elapsed();
+    // info!("Built interval tree in {:?}", duration);
 
-    let start = Instant::now();
-    gr.build_lapper(&mo.by)?;
-    let duration: Duration = start.elapsed();
-    info!("Built interval tree in {:?}", duration);
+    // let df = df!(
+    //     "seqname" => ["chr1", "chr1", "chr1", "chr1", "chr1", "chr2", "chr2", "chr3"],
+    //     "feature_type" => ["exon", "exon", "exon", "exon", "exon", "exon", "exon", "exon"],
+    //     "start" => [1i64, 12, 1, 5, 22, 1, 5, 111],
+    //     "end" => [10i64, 20, 10, 20, 30, 10, 30, 1111],
+    //     "strand"=> ["+", "+", "+", "+", "+", "+", "-", "."],
+    //     "gene_id" => [Some("g1"), Some("g1"), Some("g2"), Some("g2"), Some("g2"), Some("g3"), Some("g4"), None],
+    // )?;
 
-    let df = df!(
-        "seqnames" => ["chr1", "chr1", "chr1", "chr1", "chr1", "chr2", "chr2", "chr3"],
-        "feature_type" => ["exon", "exon", "exon", "exon", "exon", "exon", "exon", "exon"],
-        "start" => [1i64, 12, 1, 5, 22, 1, 5, 111],
-        "end" => [10i64, 20, 10, 20, 30, 10, 30, 1111],
-        "strand"=> ["+", "+", "+", "+", "+", "+", "-", "."],
-        "gene_id" => [Some("g1"), Some("g1"), Some("g2"), Some("g2"), Some("g2"), Some("g3"), Some("g4"), None],
-    )?;
+    // let mut gr = Grangers::new(df, None, None, None, IntervalType::Inclusive(1), FieldColumns::default()).unwrap();
 
-    let mut gr = Grangers::new(df, None, None, None, IntervalType::Inclusive(1)).unwrap();
-    info!("gr: {:?}", gr.df());
-    let mo = options::MergeOptions {
-        by: vec![
-            "seqnames".to_string(),
-            "gene_id".to_string(),
-            "strand".to_string(),
-        ],
-        ignore_strand: false,
-        slack: 1,
-    };
+    // // df.column("name")?.utf8()?.set(&df.column("name")?.is_null(), Some("."))?;
+    // // println!("df: {:?}", df);
 
-    gr.drop_nulls(None)?;
-    info!("drop_nulls' gr: \n{:?}", gr.df());
+    // info!("gr: {:?}", gr.df());
+    // let mo = options::MergeOptions {
+    //     by: vec![
+    //         "seqname".to_string(),
+    //         "gene_id".to_string(),
+    //         "strand".to_string(),
+    //     ],
+    //     ignore_strand: false,
+    //     slack: 1,
+    // };
 
-    let merged_gr = gr.merge(&mo)?;
+    // gr.drop_nulls(None)?;
+    // info!("drop_nulls' gr: \n{:?}", gr.df());
 
-    info!("merged gr: \n{:?}", merged_gr.df());
+    // let merged_gr = gr.merge(&mo)?;
 
-    let mut flanked_gr = gr.flank(10, options::FlankOptions::default())?;
-    info!("flanked gr: \n{:?}", flanked_gr.df());
+    // info!("merged gr: \n{:?}", merged_gr.df());
 
-    flanked_gr.extend(10, &options::ExtendOption::Both, false)?;
-    info!("extended and flanked gr: \n{:?}", flanked_gr.df());
+    // let mut flanked_gr = gr.flank(10, options::FlankOptions::default())?;
+    // info!("flanked gr: \n{:?}", flanked_gr.df());
 
-    use noodles::fasta::record::Sequence;
-    use noodles::core::position::Position;
-    let sequence = Sequence::from(b"ACGT".to_vec());
+    // flanked_gr.extend(10, &options::ExtendOption::Both, false)?;
+    // info!("extended and flanked gr: \n{:?}", flanked_gr.df());
 
-    let start = Position::try_from(1)?;
-    let end = Position::try_from(4)?;
-    let actual = sequence.slice(start..=end).unwrap();
-    
-    let expected = Sequence::from(b"CG".to_vec());
-    
-    println!("{:?}", actual);
-    println!("{:?}", expected);
-    println!("{:?}", noodles::core::region::Interval::from(start..=end));
-    println!("{:?}", (1..=5).collect::<Vec<usize>>());
-    
+    let sequence = noodles::fasta::record::Sequence::from(b"ACGT".to_vec());
+    let mut exon_vec: Vec<u8> = Vec::new();
+
+    exon_vec.extend(sequence.as_ref().iter());
+    exon_vec.extend(sequence.as_ref().iter());
+    let sequence1 = noodles::fasta::record::Sequence::from(exon_vec);
+
+    println!("{:?}", sequence);
+    println!("{:?}", sequence1);
+
+    // df.column("name")?.utf8()?.set(&df.column("name")?.is_null(), Some("."))?;
+
     // library(GenomicRanges)
     // gr <- GRanges(
-    //     seqnames = Rle(rep("chr1", 9)),
+    //     seqname = Rle(rep("chr1", 9)),
     //     ranges = IRanges(c(101, 101, 101, 121,141, 201, 201, 201, 221), end = c(150, 150, 110, 130, 150, 250, 250, 210,250), names = head(letters, 9)),
     //     strand = Rle(strand(c(rep("+",5), rep("-", 4)))),
     //     score = 1:9,

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,6 @@ fn main() -> anyhow::Result<()> {
     // flanked_gr.extend(10, &options::ExtendOption::Both, false)?;
     // info!("extended and flanked gr: \n{:?}", flanked_gr.df());
 
-
     let mut df = df!(
         "seqname" => ["chr1", "chr1", "chr1", "chr1", "chr1", "chr2", "chr2"],
         "start" => [1i64, 5, 1, 11, 22, 1, 5],
@@ -132,24 +131,18 @@ fn main() -> anyhow::Result<()> {
         df.with_column(df.column(field_columns.end()).unwrap() - interval_type.end_offset())?;
     }
 
+    // instantiate a new Grangers struct
+    let gr = Grangers {
+        df,
+        misc: None,
+        seqinfo: None,
+        lapper: None,
+        interval_type,
+        field_columns,
+    };
 
-        // instantiate a new Grangers struct
-        let gr = Grangers {
-            df,
-            misc: None,
-            seqinfo: None,
-            lapper: None,
-            interval_type,
-            field_columns,
-        };
-
-        // validate
-        gr.any_nulls(&gr.df().get_column_names(), true, true)?;
-
-
-
-
-
+    // validate
+    gr.any_nulls(&gr.df().get_column_names(), true, true)?;
 
     // df.column("name")?.utf8()?.set(&df.column("name")?.is_null(), Some("."))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ static PEAK_ALLOC: PeakAlloc = PeakAlloc;
 
 fn main() -> anyhow::Result<()> {
     let gtf_file = PathBuf::from(
-        "/mnt/scratch4/dongze/af_example_best_practices_book/af_xmpl_run/data/refdata-gex-GRCh38-2020-A/genes/genes.gtf",
+        "/mnt/scratch4/dongze/af_example_best_practices_book/af_xmpl_run/data/refdata-gex-GRCh38-2020-A/genes/genes.gtf.gz",
     );
 
     // let _fasta_file = PathBuf::from(

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> anyhow::Result<()> {
     let fasta_file = PathBuf::from(args.get(2).unwrap());
 
     let start = Instant::now();
-    let mut gr = Grangers::from_gtf(gtf_file.as_path(), false)?;
+    let mut gr = Grangers::from_gtf(gtf_file.as_path(), true)?;
     let duration: Duration = start.elapsed();
     info!("Built Grangers in {:?}", duration);
     info!("Grangers shape {:?}", gr.df().shape());

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,10 @@ use std::time::{Duration, Instant};
 use tracing::info;
 use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*, EnvFilter};
 pub mod grangers;
-use crate::grangers::options::FieldColumns;
-// use crate::grangers::{FileFormat, FlankOptions};
-use crate::grangers::{options, Grangers, IntervalType};
+use crate::grangers::{options, Grangers};
 use peak_alloc::PeakAlloc;
 use polars::prelude::*;
+use tracing::warn;
 
 #[global_allocator]
 static PEAK_ALLOC: PeakAlloc = PeakAlloc;
@@ -30,12 +29,100 @@ fn main() -> anyhow::Result<()> {
     let args: Vec<String> = env::args().collect();
     let gtf_file = PathBuf::from(args.get(1).unwrap());
     let fasta_file = PathBuf::from(args.get(2).unwrap());
+    let out_dir = PathBuf::from(args.get(3).unwrap());
 
+
+    // create the folder if it doesn't exist
+    std::fs::create_dir_all(out_dir)?;
+    let out_fa = out_dir.join("splici.fa");
+
+    // 1. we read the gtf file as grangers. This will make sure that the eight fields are there.
     let start = Instant::now();
     let mut gr = Grangers::from_gtf(gtf_file.as_path(), true)?;
     let duration: Duration = start.elapsed();
     info!("Built Grangers in {:?}", duration);
     info!("Grangers shape {:?}", gr.df().shape());
+
+    // we get the exon df and validate it
+    // this will make sure that each exon has a valid transcript ID, and the exon numbers are valid
+    let mut exon_gr = gr.exons(None, true)?;
+    let mut fc = exon_gr.field_columns().clone();
+    let df = exon_gr.df_mut();
+    
+    // we then make sure that the gene_id and gene_name fields are not both missing
+    if fc.gene_id().is_none() && fc.gene_name().is_none() {
+        anyhow::bail!("The input GTF file must have either gene_id or gene_name field. Cannot proceed");
+    } else if fc.gene_id().is_none() {
+        warn!("The input GTF file do not have a gene_id field. We will use gene_name as gene_id");
+        // we get gene name and rename it to gene_id
+        let mut gene_id = df.column(fc.gene_name().unwrap())?.clone();
+        gene_id.rename("gene_id");
+        fc.update("gene_id", "gene_id")?;
+        // push to the df
+        df.with_column(gene_id)?;
+    } else if fc.gene_name().is_none() {
+        warn!("The input GTF file do not have a gene_name field. We will use gene_id as gene_name.");
+        // we get gene id and rename it to gene_name
+        let mut gene_name = df.column(fc.gene_id().unwrap())?.clone();
+        gene_name.rename("gene_name");
+        fc.update("gene_name", "gene_name")?;
+        // push to the df
+        df.with_column(gene_name)?;
+    }
+
+    exon_gr.field_columns = fc;
+    let gene_id_s = exon_gr.get_column_name("gene_id", false)?.to_string();
+    let gene_id = gene_id_s.as_str();
+    let gene_name_s = exon_gr.get_column_name("gene_name", false)?.to_string();
+    let gene_name = gene_name_s.as_str();
+    let transcript_id_s = exon_gr.get_column_name("transcript_id", false)?.to_string();
+    let transcript_id = transcript_id_s.as_str();
+    
+    // Next, we fill the missing gene_id and gene_name fields
+    if exon_gr.any_nulls(&[gene_id, gene_name], false, false)? {
+        warn!("Found missing gene_id and/or gene_name; Imputing. If both missing, will impute using transcript_id; Otherwise, will impute using the existing one.");
+        exon_gr.df = exon_gr.df.lazy().with_columns([
+            when(col(gene_id).is_null())
+                .then(
+                    when(col(gene_name).is_null())
+                    .then(col(transcript_id))
+                    .otherwise(col(gene_name))
+                )
+                .otherwise(
+                    col(gene_id)
+                )
+                .alias(gene_id),
+            when(col(gene_name).is_null())
+                .then(
+                    when(col(gene_id).is_null())
+                    .then(col(transcript_id))
+                    .otherwise(col(gene_id))
+                )
+                .otherwise(
+                    col(gene_name)
+                )
+                .alias(gene_name),
+        ])
+        .collect()?;
+    }
+    
+    // Next, we get the gene_name to id mapping
+    let gene_name_to_id = exon_gr.df().select([gene_name, gene_id])?.unique(None,UniqueKeepStrategy::Any, None)?;
+
+    // Next, we write the transcript seuqences 
+    exon_gr.write_transcript_sequences(&fasta_file, &out_fa, None, true, true)?;
+
+    // next, we write transcripts and unspliced/itrons
+
+        // 2. we quit if the required attributes are not valid:
+            // - if transcript_id field dosn't exist
+            // - if transcript_id field exists but is null for some exon features
+            // - if gene_name and gene_id both are missing,
+    // 3. we warn if one of gene_name and gene_id fields is missing, and copy the existing one as the missing one.
+    // 4. If gene_name and/or gene_id fields contain null values, we imputet them:
+    //      - If gene_name is missing, we impute it with gene_id
+    //      - If gene_id is missing, we impute it with gene_name
+
     let start = Instant::now();
     gr.get_transcript_sequences(&fasta_file, None, true)?;
     let duration: Duration = start.elapsed();
@@ -43,37 +130,46 @@ fn main() -> anyhow::Result<()> {
 
     gr.df = gr.df.head(Some(100000));
     let start = Instant::now();
-    gr.get_sequences(&fasta_file, false, None, &options::OOBOption::Skip)?;
+    gr.get_sequences(&fasta_file, false, None, options::OOBOption::Skip)?;
     let duration: Duration = start.elapsed();
     info!("extract first 100,000 sequences in {:?}", duration);
 
+    let mo = options::MergeOptions::new(&["seqname", "gene_id", "transcript_id"], false, 1)?;
+    let start = Instant::now();
+    gr.merge(&["seqname", "gene_id", "transcript_id"], false, None)?;
+    let duration: Duration = start.elapsed();
+    info!("Merged overlapping ranges in {:?}", duration);
 
+    let start = Instant::now();
+    gr.flank(10, options::FlankOptions::default())?;
+    let duration: Duration = start.elapsed();
+    info!("Flanked ranges in {:?}", duration);
 
-    // let mo = options::MergeOptions::new(&["seqname", "gene_id", "transcript_id"], false, 1)?;
-    // let start = Instant::now();
-    // gr.merge(&["seqname", "gene_id", "transcript_id"], false, None)?;
-    // let duration: Duration = start.elapsed();
-    // info!("Merged overlapping ranges in {:?}", duration);
+    let start = Instant::now();
+    gr.introns(options::IntronsBy::Gene, None, true)?;
+    let duration: Duration = start.elapsed();
+    info!("Built intron's Grangers in {:?}", duration);
 
-    // let start = Instant::now();
-    // gr.flank(10, options::FlankOptions::default())?;
-    // let duration: Duration = start.elapsed();
-    // info!("Flanked ranges in {:?}", duration);
+    let start = Instant::now();
+    gr.extend(10, &options::ExtendOption::Both, false)?;
+    let duration: Duration = start.elapsed();
+    info!("Extended ranges in {:?}", duration);
 
-    // let start = Instant::now();
-    // gr.introns(options::IntronsBy::Gene, None, true)?;
-    // let duration: Duration = start.elapsed();
-    // info!("Built intron's Grangers in {:?}", duration);
+    let start = Instant::now();
+    gr.build_lapper(&mo.by)?;
+    let duration: Duration = start.elapsed();
+    info!("Built interval tree in {:?}", duration);
 
-    // let start = Instant::now();
-    // gr.extend(10, &options::ExtendOption::Both, false)?;
-    // let duration: Duration = start.elapsed();
-    // info!("Extended ranges in {:?}", duration);
+    // 2. we quit if the required attributes are not valid:
+            // - if transcript_id field dosn't exist
+            // - if transcript_id field exists but is null for some exon features
+            // - if gene_name and gene_id both are missing,
+    // 3. we warn if one of gene_name and gene_id fields is missing, and copy the existing one as the missing one.
+    // 4. If gene_name and/or gene_id fields contain null values, we imputet them:
+    //      - If gene_name is missing, we impute it with gene_id
+    //     - If gene_id is missing, we impute it with gene_name
+    //     - If both are missing, we impute them with transcript_id
 
-    // let start = Instant::now();
-    // gr.build_lapper(&mo.by)?;
-    // let duration: Duration = start.elapsed();
-    // info!("Built interval tree in {:?}", duration);
 
     // let df = df!(
     //     "seqname" => ["chr1", "chr1", "chr1", "chr1", "chr1", "chr2", "chr2", "chr3"],
@@ -112,7 +208,6 @@ fn main() -> anyhow::Result<()> {
 
     // flanked_gr.extend(10, &options::ExtendOption::Both, false)?;
     // info!("extended and flanked gr: \n{:?}", flanked_gr.df());
-
 
     // library(GenomicRanges)
     // gr <- GRanges(

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,11 +36,18 @@ fn main() -> anyhow::Result<()> {
     let duration: Duration = start.elapsed();
     info!("Built Grangers in {:?}", duration);
     info!("Grangers shape {:?}", gr.df().shape());
-
     let start = Instant::now();
     gr.get_transcript_sequences(&fasta_file, None, true)?;
     let duration: Duration = start.elapsed();
     info!("extract transcript sequences in {:?}", duration);
+
+    gr.df = gr.df.head(Some(100000));
+    let start = Instant::now();
+    gr.get_sequences(&fasta_file, false, None, &options::OOBOption::Skip)?;
+    let duration: Duration = start.elapsed();
+    info!("extract first 100,000 sequences in {:?}", duration);
+
+
 
     // let mo = options::MergeOptions::new(&["seqname", "gene_id", "transcript_id"], false, 1)?;
     // let start = Instant::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,101 +14,111 @@ use polars::prelude::*;
 static PEAK_ALLOC: PeakAlloc = PeakAlloc;
 
 fn main() -> anyhow::Result<()> {
-    // Check the `RUST_LOG` variable for the logger level and
-    // respect the value found there. If this environment
-    // variable is not set then set the logging level to
-    // INFO.
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(
-            EnvFilter::builder()
-                .with_default_directive(LevelFilter::INFO.into())
-                .from_env_lossy(),
-        )
-        .init();
+    // // Check the `RUST_LOG` variable for the logger level and
+    // // respect the value found there. If this environment
+    // // variable is not set then set the logging level to
+    // // INFO.
+    // tracing_subscriber::registry()
+    //     .with(fmt::layer())
+    //     .with(
+    //         EnvFilter::builder()
+    //             .with_default_directive(LevelFilter::INFO.into())
+    //             .from_env_lossy(),
+    //     )
+    //     .init();
 
-    let args: Vec<String> = env::args().collect();
-    let gtf_file = PathBuf::from(args.get(1).unwrap());
+    // let args: Vec<String> = env::args().collect();
+    // let gtf_file = PathBuf::from(args.get(1).unwrap());
 
-    // let _fasta_file = PathBuf::from(
-    //     "/mnt/scratch3/alevin_fry_submission/refs/refdata-gex-GRCh38-2020-A/fasta/genome.fa",
-    // );
+    // // let _fasta_file = PathBuf::from(
+    // //     "/mnt/scratch3/alevin_fry_submission/refs/refdata-gex-GRCh38-2020-A/fasta/genome.fa",
+    // // );
 
-    // println!("Start parsing GTF");
+    // // println!("Start parsing GTF");
+    // // let start = Instant::now();
+
+    // // let duration: Duration = start.elapsed();
+    // // println!("Parsed GTF in {:?}", duration);
+
     // let start = Instant::now();
-
+    // let mut gr = Grangers::from_gtf(gtf_file.as_path(), false)?;
     // let duration: Duration = start.elapsed();
-    // println!("Parsed GTF in {:?}", duration);
+    // info!("Built Grangers in {:?}", duration);
+    // info!("Grangers shape {:?}", gr.df().shape());
 
-    let start = Instant::now();
-    let mut gr = Grangers::from_gtf(gtf_file.as_path(), false)?;
-    let duration: Duration = start.elapsed();
-    info!("Built Grangers in {:?}", duration);
-    info!("Grangers shape {:?}", gr.df().shape());
+    // let mo = options::MergeOptions::new(&["seqname", "gene_id", "transcript_id"], false, 1)?;
+    // let start = Instant::now();
+    // gr.merge(&mo)?;
+    // let duration: Duration = start.elapsed();
+    // info!("Merged overlapping ranges in {:?}", duration);
 
-    let mo = options::MergeOptions::new(&["seqname", "gene_id", "transcript_id"], false, 1)?;
-    let start = Instant::now();
-    gr.merge(&mo)?;
-    let duration: Duration = start.elapsed();
-    info!("Merged overlapping ranges in {:?}", duration);
+    // let start = Instant::now();
+    // gr.flank(10, options::FlankOptions::default())?;
+    // let duration: Duration = start.elapsed();
+    // info!("Flanked ranges in {:?}", duration);
 
-    let start = Instant::now();
-    gr.flank(10, options::FlankOptions::default())?;
-    let duration: Duration = start.elapsed();
-    info!("Flanked ranges in {:?}", duration);
+    // let start = Instant::now();
+    // gr.introns(options::IntronsBy::Gene, None, true)?;
+    // let duration: Duration = start.elapsed();
+    // info!("Built intron's Grangers in {:?}", duration);
 
-    let start = Instant::now();
-    gr.introns(options::IntronsBy::Gene, None, true)?;
-    let duration: Duration = start.elapsed();
-    info!("Built intron's Grangers in {:?}", duration);
+    // let start = Instant::now();
+    // gr.extend(10, &options::ExtendOption::Both, false)?;
+    // let duration: Duration = start.elapsed();
+    // info!("Extended ranges in {:?}", duration);
 
-    let start = Instant::now();
-    gr.extend(10, &options::ExtendOption::Both, false)?;
-    let duration: Duration = start.elapsed();
-    info!("Extended ranges in {:?}", duration);
+    // let start = Instant::now();
+    // gr.build_lapper(&mo.by)?;
+    // let duration: Duration = start.elapsed();
+    // info!("Built interval tree in {:?}", duration);
 
-    let start = Instant::now();
-    gr.build_lapper(&mo.by)?;
-    let duration: Duration = start.elapsed();
-    info!("Built interval tree in {:?}", duration);
+    // let df = df!(
+    //     "seqname" => ["chr1", "chr1", "chr1", "chr1", "chr1", "chr2", "chr2", "chr3"],
+    //     "feature_type" => ["exon", "exon", "exon", "exon", "exon", "exon", "exon", "exon"],
+    //     "start" => [1i64, 12, 1, 5, 22, 1, 5, 111],
+    //     "end" => [10i64, 20, 10, 20, 30, 10, 30, 1111],
+    //     "strand"=> ["+", "+", "+", "+", "+", "+", "-", "."],
+    //     "gene_id" => [Some("g1"), Some("g1"), Some("g2"), Some("g2"), Some("g2"), Some("g3"), Some("g4"), None],
+    // )?;
 
-    let df = df!(
-        "seqname" => ["chr1", "chr1", "chr1", "chr1", "chr1", "chr2", "chr2", "chr3"],
-        "feature_type" => ["exon", "exon", "exon", "exon", "exon", "exon", "exon", "exon"],
-        "start" => [1i64, 12, 1, 5, 22, 1, 5, 111],
-        "end" => [10i64, 20, 10, 20, 30, 10, 30, 1111],
-        "strand"=> ["+", "+", "+", "+", "+", "+", "-", "."],
-        "gene_id" => [Some("g1"), Some("g1"), Some("g2"), Some("g2"), Some("g2"), Some("g3"), Some("g4"), None],
-    )?;
+    // let mut gr = Grangers::new(df, None, None, None, IntervalType::Inclusive(1), FieldColumns::default()).unwrap();
 
-    let mut gr = Grangers::new(df, None, None, None, IntervalType::Inclusive(1), FieldColumns::default()).unwrap();
+    // // df.column("name")?.utf8()?.set(&df.column("name")?.is_null(), Some("."))?;
+    // // println!("df: {:?}", df);
 
-    // df.column("name")?.utf8()?.set(&df.column("name")?.is_null(), Some("."))?;
-    // println!("df: {:?}", df);
+    // info!("gr: {:?}", gr.df());
+    // let mo = options::MergeOptions {
+    //     by: vec![
+    //         "seqname".to_string(),
+    //         "gene_id".to_string(),
+    //         "strand".to_string(),
+    //     ],
+    //     ignore_strand: false,
+    //     slack: 1,
+    // };
 
-    info!("gr: {:?}", gr.df());
-    let mo = options::MergeOptions {
-        by: vec![
-            "seqname".to_string(),
-            "gene_id".to_string(),
-            "strand".to_string(),
-        ],
-        ignore_strand: false,
-        slack: 1,
-    };
+    // gr.drop_nulls(None)?;
+    // info!("drop_nulls' gr: \n{:?}", gr.df());
 
-    gr.drop_nulls(None)?;
-    info!("drop_nulls' gr: \n{:?}", gr.df());
+    // let merged_gr = gr.merge(&mo)?;
 
-    let merged_gr = gr.merge(&mo)?;
+    // info!("merged gr: \n{:?}", merged_gr.df());
 
-    info!("merged gr: \n{:?}", merged_gr.df());
+    // let mut flanked_gr = gr.flank(10, options::FlankOptions::default())?;
+    // info!("flanked gr: \n{:?}", flanked_gr.df());
 
-    let mut flanked_gr = gr.flank(10, options::FlankOptions::default())?;
-    info!("flanked gr: \n{:?}", flanked_gr.df());
+    // flanked_gr.extend(10, &options::ExtendOption::Both, false)?;
+    // info!("extended and flanked gr: \n{:?}", flanked_gr.df());
 
-    flanked_gr.extend(10, &options::ExtendOption::Both, false)?;
-    info!("extended and flanked gr: \n{:?}", flanked_gr.df());
+
+    let sequence = noodles::fasta::record::Sequence::from(b"ACGT".to_vec());
+
+    let start = noodles::core::Position::try_from(2)?;
+    println!("{:?}", sequence.get(start));
+    assert_eq!(sequence.get(start), Some(&b'C'));
+
+    assert_eq!(sequence.get(start..), Some(&b"CGT"[..]));
+
 
 
     // df.column("name")?.utf8()?.set(&df.column("name")?.is_null(), Some("."))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,111 +14,102 @@ use polars::prelude::*;
 static PEAK_ALLOC: PeakAlloc = PeakAlloc;
 
 fn main() -> anyhow::Result<()> {
-    // // Check the `RUST_LOG` variable for the logger level and
-    // // respect the value found there. If this environment
-    // // variable is not set then set the logging level to
-    // // INFO.
-    // tracing_subscriber::registry()
-    //     .with(fmt::layer())
-    //     .with(
-    //         EnvFilter::builder()
-    //             .with_default_directive(LevelFilter::INFO.into())
-    //             .from_env_lossy(),
-    //     )
-    //     .init();
+    // Check the `RUST_LOG` variable for the logger level and
+    // respect the value found there. If this environment
+    // variable is not set then set the logging level to
+    // INFO.
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
 
-    // let args: Vec<String> = env::args().collect();
-    // let gtf_file = PathBuf::from(args.get(1).unwrap());
+    let args: Vec<String> = env::args().collect();
+    let gtf_file = PathBuf::from(args.get(1).unwrap());
 
-    // // let _fasta_file = PathBuf::from(
-    // //     "/mnt/scratch3/alevin_fry_submission/refs/refdata-gex-GRCh38-2020-A/fasta/genome.fa",
-    // // );
+    // let _fasta_file = PathBuf::from(
+    //     "/mnt/scratch3/alevin_fry_submission/refs/refdata-gex-GRCh38-2020-A/fasta/genome.fa",
+    // );
 
-    // // println!("Start parsing GTF");
-    // // let start = Instant::now();
-
-    // // let duration: Duration = start.elapsed();
-    // // println!("Parsed GTF in {:?}", duration);
-
+    // println!("Start parsing GTF");
     // let start = Instant::now();
-    // let mut gr = Grangers::from_gtf(gtf_file.as_path(), false)?;
+
     // let duration: Duration = start.elapsed();
-    // info!("Built Grangers in {:?}", duration);
-    // info!("Grangers shape {:?}", gr.df().shape());
+    // println!("Parsed GTF in {:?}", duration);
 
-    // let mo = options::MergeOptions::new(&vec!["seqname", "gene_id", "transcript_id"], false, 1)?;
-    // let start = Instant::now();
-    // gr.merge(&mo)?;
-    // let duration: Duration = start.elapsed();
-    // info!("Merged overlapping ranges in {:?}", duration);
+    let start = Instant::now();
+    let mut gr = Grangers::from_gtf(gtf_file.as_path(), false)?;
+    let duration: Duration = start.elapsed();
+    info!("Built Grangers in {:?}", duration);
+    info!("Grangers shape {:?}", gr.df().shape());
 
-    // let start = Instant::now();
-    // gr.flank(10, options::FlankOptions::default())?;
-    // let duration: Duration = start.elapsed();
-    // info!("Flanked ranges in {:?}", duration);
+    let mo = options::MergeOptions::new(&["seqname", "gene_id", "transcript_id"], false, 1)?;
+    let start = Instant::now();
+    gr.merge(&mo)?;
+    let duration: Duration = start.elapsed();
+    info!("Merged overlapping ranges in {:?}", duration);
 
-    // let start = Instant::now();
-    // gr.introns(options::IntronsBy::Gene, None, true)?;
-    // let duration: Duration = start.elapsed();
-    // info!("Built intron's Grangers in {:?}", duration);
+    let start = Instant::now();
+    gr.flank(10, options::FlankOptions::default())?;
+    let duration: Duration = start.elapsed();
+    info!("Flanked ranges in {:?}", duration);
 
-    // let start = Instant::now();
-    // gr.extend(10, &options::ExtendOption::Both, false)?;
-    // let duration: Duration = start.elapsed();
-    // info!("Extended ranges in {:?}", duration);
+    let start = Instant::now();
+    gr.introns(options::IntronsBy::Gene, None, true)?;
+    let duration: Duration = start.elapsed();
+    info!("Built intron's Grangers in {:?}", duration);
 
-    // let start = Instant::now();
-    // gr.build_lapper(&mo.by)?;
-    // let duration: Duration = start.elapsed();
-    // info!("Built interval tree in {:?}", duration);
+    let start = Instant::now();
+    gr.extend(10, &options::ExtendOption::Both, false)?;
+    let duration: Duration = start.elapsed();
+    info!("Extended ranges in {:?}", duration);
 
-    // let df = df!(
-    //     "seqname" => ["chr1", "chr1", "chr1", "chr1", "chr1", "chr2", "chr2", "chr3"],
-    //     "feature_type" => ["exon", "exon", "exon", "exon", "exon", "exon", "exon", "exon"],
-    //     "start" => [1i64, 12, 1, 5, 22, 1, 5, 111],
-    //     "end" => [10i64, 20, 10, 20, 30, 10, 30, 1111],
-    //     "strand"=> ["+", "+", "+", "+", "+", "+", "-", "."],
-    //     "gene_id" => [Some("g1"), Some("g1"), Some("g2"), Some("g2"), Some("g2"), Some("g3"), Some("g4"), None],
-    // )?;
+    let start = Instant::now();
+    gr.build_lapper(&mo.by)?;
+    let duration: Duration = start.elapsed();
+    info!("Built interval tree in {:?}", duration);
 
-    // let mut gr = Grangers::new(df, None, None, None, IntervalType::Inclusive(1), FieldColumns::default()).unwrap();
+    let df = df!(
+        "seqname" => ["chr1", "chr1", "chr1", "chr1", "chr1", "chr2", "chr2", "chr3"],
+        "feature_type" => ["exon", "exon", "exon", "exon", "exon", "exon", "exon", "exon"],
+        "start" => [1i64, 12, 1, 5, 22, 1, 5, 111],
+        "end" => [10i64, 20, 10, 20, 30, 10, 30, 1111],
+        "strand"=> ["+", "+", "+", "+", "+", "+", "-", "."],
+        "gene_id" => [Some("g1"), Some("g1"), Some("g2"), Some("g2"), Some("g2"), Some("g3"), Some("g4"), None],
+    )?;
 
-    // // df.column("name")?.utf8()?.set(&df.column("name")?.is_null(), Some("."))?;
-    // // println!("df: {:?}", df);
+    let mut gr = Grangers::new(df, None, None, None, IntervalType::Inclusive(1), FieldColumns::default()).unwrap();
 
-    // info!("gr: {:?}", gr.df());
-    // let mo = options::MergeOptions {
-    //     by: vec![
-    //         "seqname".to_string(),
-    //         "gene_id".to_string(),
-    //         "strand".to_string(),
-    //     ],
-    //     ignore_strand: false,
-    //     slack: 1,
-    // };
+    // df.column("name")?.utf8()?.set(&df.column("name")?.is_null(), Some("."))?;
+    // println!("df: {:?}", df);
 
-    // gr.drop_nulls(None)?;
-    // info!("drop_nulls' gr: \n{:?}", gr.df());
+    info!("gr: {:?}", gr.df());
+    let mo = options::MergeOptions {
+        by: vec![
+            "seqname".to_string(),
+            "gene_id".to_string(),
+            "strand".to_string(),
+        ],
+        ignore_strand: false,
+        slack: 1,
+    };
 
-    // let merged_gr = gr.merge(&mo)?;
+    gr.drop_nulls(None)?;
+    info!("drop_nulls' gr: \n{:?}", gr.df());
 
-    // info!("merged gr: \n{:?}", merged_gr.df());
+    let merged_gr = gr.merge(&mo)?;
 
-    // let mut flanked_gr = gr.flank(10, options::FlankOptions::default())?;
-    // info!("flanked gr: \n{:?}", flanked_gr.df());
+    info!("merged gr: \n{:?}", merged_gr.df());
 
-    // flanked_gr.extend(10, &options::ExtendOption::Both, false)?;
-    // info!("extended and flanked gr: \n{:?}", flanked_gr.df());
+    let mut flanked_gr = gr.flank(10, options::FlankOptions::default())?;
+    info!("flanked gr: \n{:?}", flanked_gr.df());
 
-    let sequence = noodles::fasta::record::Sequence::from(b"ACGT".to_vec());
-    let mut exon_vec: Vec<u8> = Vec::new();
+    flanked_gr.extend(10, &options::ExtendOption::Both, false)?;
+    info!("extended and flanked gr: \n{:?}", flanked_gr.df());
 
-    exon_vec.extend(sequence.as_ref().iter());
-    exon_vec.extend(sequence.as_ref().iter());
-    let sequence1 = noodles::fasta::record::Sequence::from(exon_vec);
-
-    println!("{:?}", sequence);
-    println!("{:?}", sequence1);
 
     // df.column("name")?.utf8()?.set(&df.column("name")?.is_null(), Some("."))?;
 


### PR DESCRIPTION
I added tons of validation steps to make sure that when calling the methods, merge, introns etc. We will reject invalid cases.

Now we have two get sequence functions:
get_transcript_sequences() extracts the exon sequences of each transcript, sticks them together as a long sequence, and returns a vector of noodles::fasta::Record.

get_sequences() extract the sequence of each feature (each row in the data frame) and return them as a vector of noodles::fasta::Record.

Therefore, we have all functionalities for roers. The only thing left is the validation of the GTF file, as we did in pyroe.

There are only a few things to do:
1. modify the get sequence functions as write sequences functions
3. write a GTF writer by collapsing all attributes into one column. This function will use polars csv writer 