### PR TITLE
New seq iter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,4 @@ peak_alloc = "0.2.0"
 bedrs = "0.0.26"
 rust-lapper = "1.1.0"
 clap = { version = "4.3.11", features = ["derive", "cargo", "deprecated", "wrap_help", "help", "usage", "error-context"] } 
+next-gen = "0.1.1"

--- a/src/grangers_info.rs
+++ b/src/grangers_info.rs
@@ -2645,6 +2645,7 @@ impl GrangersSeqIter {
 impl Iterator for GrangersSeqIter {
     type Item = Record;
 
+    #[allow(clippy::question_mark)]
     fn next(&mut self) -> Option<Self::Item> {
 
         loop {
@@ -2752,9 +2753,7 @@ impl Iterator for GrangersSeqIter {
 
                 // if we got to this point, and we weren't able to fill in 
                 // self.chr_seq_iter, then the iterator should be exhausted
-                if self.chr_seq_iter.is_none() { 
-                    return None;
-                }
+                if self.chr_seq_iter.is_none() { return None; }
             }
         }
     }

--- a/src/grangers_info.rs
+++ b/src/grangers_info.rs
@@ -2647,7 +2647,6 @@ impl Iterator for GrangersSeqIter {
 
     fn next(&mut self) -> Option<Self::Item> {
 
-        println!("hello world");
         loop {
             // check if the inner iterator exists and, if so, if we have 
             // elements to yield from it.
@@ -2666,7 +2665,6 @@ impl Iterator for GrangersSeqIter {
                 // go to the top of the loop.
                 self.chr_seq_iter = None;
             } else { 
-                println!("here else");
                 // in this branch, chr_seq_iter was None, so either we exhausted the previous
                 // inner iterator, or we haven't created it yet.
                 // we iterate the fasta reader. For each fasta reacord (usually chromosome), we do
@@ -2706,7 +2704,7 @@ impl Iterator for GrangersSeqIter {
                         .name()
                         .strip_suffix(' ')
                         .unwrap_or(self.seq_record.name());
-                    println!("chr_name : {}", chr_name);
+
                     self.chr_gr = Some(
                         self.essential_gr
                             .filter(self.filt_opt.seqname.clone(), &[chr_name.to_string()])
@@ -2714,12 +2712,9 @@ impl Iterator for GrangersSeqIter {
                     );
 
                     if self.chr_gr.as_ref().unwrap().df().height() == 0 {
-                        println!("empty! had chr_gr with height {}", self.chr_gr.as_ref().unwrap().df().height());
                         self.chr_gr = None;
                         continue;
-                    } else {
-                        println!("had chr_gr with height {}", self.chr_gr.as_ref().unwrap().df().height());
-                    }
+                    } 
 
                     self.name_vec_iter = self
                         .chr_gr

--- a/tests/test_iterator.rs
+++ b/tests/test_iterator.rs
@@ -17,11 +17,12 @@ fn test_iterator() -> anyhow::Result<()> {
     let mut gr = Grangers::from_gtf(gtf, true)?;
     let gene_id_s = gr.get_column_name("gene_id", false)?;
 
-    let mut siter = gr.iter_sequences(fa, false, Some(&gene_id_s), options::OOBOption::Truncate)?;
+    let siter = gr.iter_sequences(fa, false, Some(&gene_id_s), options::OOBOption::Truncate)?;
 
     // Is this safe?
     let mut svec: Vec<Record> = Pin::into_inner(siter).collect();
 
+    // could also do this
     //while let Some(r) = siter.next() {
     //svec.push(r);
     //}
@@ -35,6 +36,9 @@ fn test_iterator() -> anyhow::Result<()> {
 
     println!("total records collected by get_sequences = {}", rvec.len());
 
+    // the iterator version and the eager function call should return 
+    // equivalent sequences modulo order. Thus, after sorting, they 
+    // should compare as equal.
     svec.sort_unstable_by_key( |x| x.name().to_owned() );
     rvec.sort_unstable_by_key( |x| x.name().to_owned() );
 

--- a/tests/test_iterator.rs
+++ b/tests/test_iterator.rs
@@ -1,0 +1,44 @@
+use grangers::{options, Grangers};
+use std::path::Path;
+use std::pin::Pin;
+use noodles::fasta::record::Record;
+use anyhow;
+
+#[test]
+fn test_iterator() -> anyhow::Result<()> {
+
+    let gtf = Path::new("data/refdata-gex-GRCh38-2020-A/genes/genes_small.gtf");
+    let fa = Path::new("data/refdata-gex-GRCh38-2020-A/fasta/genome.fa");
+
+    if !gtf.exists() || !fa.exists() {
+        panic!("cannot run `test_iterator` integration test without the test data");
+    }
+
+    let mut gr = Grangers::from_gtf(gtf, true)?;
+    let gene_id_s = gr.get_column_name("gene_id", false)?;
+
+    let mut siter = gr.iter_sequences(fa, false, Some(&gene_id_s), options::OOBOption::Truncate)?;
+
+    // Is this safe?
+    let mut svec: Vec<Record> = Pin::into_inner(siter).collect();
+
+    //while let Some(r) = siter.next() {
+    //svec.push(r);
+    //}
+
+    println!("total records collected by iterator = {}", svec.len());
+
+    let mut rvec: Vec<Record> = gr.get_sequences(fa, false, Some(&gene_id_s), options::OOBOption::Truncate)?
+        .into_iter()
+        .flatten()
+        .collect();
+
+    println!("total records collected by get_sequences = {}", rvec.len());
+
+    svec.sort_unstable_by_key( |x| x.name().to_owned() );
+    rvec.sort_unstable_by_key( |x| x.name().to_owned() );
+
+    assert_eq!(svec, rvec);
+
+    Ok(())
+}


### PR DESCRIPTION
Merge basic sequence iterator into dev. It's a bit less ergonomic due to the `Pin<Box<>>` requirement but still quite nice.  Right now this is implemented only for features directly and not for `transcript_sequences`.  @DongzeHE: we should think about the easiest way to minimize redundancy to share code between `get_sequences` and `get_transcript_seqeunces`.  Likewise, we could now implement `get_sequences` easily in terms of the iterator:

```
get_sequences(args) -> Vec<Record> {
Pin::into_inner(iter_sequences(args)).collect()
}
```

accounting, of course, for the fact that the iterator returns `Record` rather than `Option<Record>` (i.e. implicitly dropping any record for which we would have `None`).  Is there a reason `get_sequences` returns `Vec<Option<Record>>` rather than `Vec<Record>`?