### PR TITLE
Fix panic in ChrRowSeqIter by replacing Series iterators with owned Vecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.5.0](https://github.com/COMBINE-lab/grangers/compare/v0.4.0...v0.5.0) (2025-01-24)
+
+
+### Features
+
+* allow reading from gzipped fasta, think more about static lifetime bound ([b235c03](https://github.com/COMBINE-lab/grangers/commit/b235c03d9430da0532960f72d56f2b9877e6d019))
+* upgrade deps ([89af5b9](https://github.com/COMBINE-lab/grangers/commit/89af5b9d6a5b7419b7d23b071086cd7e0eba0e99))
+
+
+### Bug Fixes
+
+* GZDecoder to MultiGZDecoder ([0d00fd1](https://github.com/COMBINE-lab/grangers/commit/0d00fd1624b963c6509ea459a43d72b40bc49a4e))
+
 ## [0.4.0](https://github.com/COMBINE-lab/grangers/compare/v0.3.1...v0.4.0) (2023-10-28)
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ anyhow = "1.0"
 flate2 = { version = "1.0.35", features = [
   "zlib-ng",
 ], default-features = false }
-noodles = { version = "0.90.0", features = ["gtf", "gff", "fasta", "core"] }
+noodles = { version = "0.104.0", features = ["gtf", "gff", "fasta", "core"] }
 tracing = "0.1.41"
-polars = { version = "0.45.1", features = [
+polars = { version = "0.49.1", features = [
   "lazy",
   "dataframe_arithmetic",
   "checked_arithmetic",
@@ -45,7 +45,10 @@ polars = { version = "0.45.1", features = [
   "strings",
   "is_in",
   "abs",
+  "regex",
+  "timezones",
+  "polars-ops"
 ] }
 rust-lapper = "1.1.0"
 lazy_static = "1.5.0"
-nutype = "0.5.1"
+nutype = "0.6.2"

--- a/src/grangers_utils.rs
+++ b/src/grangers_utils.rs
@@ -4,11 +4,12 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::Path;
 use tracing::trace;
+use noodles::fasta::io::Reader as NoodlesFastaReader;
 
 /// Type alias for a noodles FASTA reader that can read from
 /// a `dyn BufRead`. It is used to allow reading from either
 /// a compressed or uncompressed FASTA file.
-pub type FastaReader = noodles::fasta::Reader<Box<dyn BufRead>>;
+pub type FastaReader = NoodlesFastaReader<Box<dyn BufRead>>;
 
 pub(crate) const VALIDSTRANDS: [&str; 2] = ["+", "-"];
 
@@ -229,11 +230,11 @@ pub fn get_noodles_reader_from_path<T: AsRef<Path>>(p: T) -> anyhow::Result<Fast
     // Now, we read the fasta file and process each reference sequence at a time
     if is_gzipped(&mut inner_rdr)? {
         trace!("auto-detected gzipped FASTA file - reading via decompression");
-        Ok(noodles::fasta::Reader::new(Box::new(BufReader::new(
+        Ok(NoodlesFastaReader::new(Box::new(BufReader::new(
             MultiGzDecoder::new(inner_rdr),
         ))))
     } else {
-        Ok(noodles::fasta::Reader::new(Box::new(inner_rdr)))
+        Ok(NoodlesFastaReader::new(Box::new(inner_rdr)))
     }
 }
 
@@ -250,11 +251,11 @@ pub fn get_noodles_reader_from_reader(r: impl Read + 'static) -> anyhow::Result<
     // Now, we read the fasta file and process each reference sequence at a time
     if is_gzipped(&mut inner_rdr)? {
         trace!("auto-detected gzipped FASTA file - reading via decompression");
-        Ok(noodles::fasta::Reader::new(Box::new(BufReader::new(
+        Ok(NoodlesFastaReader::new(Box::new(BufReader::new(
             MultiGzDecoder::new(inner_rdr),
         ))))
     } else {
-        Ok(noodles::fasta::Reader::new(Box::new(inner_rdr)))
+        Ok(NoodlesFastaReader::new(Box::new(inner_rdr)))
     }
 }
 

--- a/src/reader/fasta.rs
+++ b/src/reader/fasta.rs
@@ -250,7 +250,7 @@ pub fn get_chromsize<T: AsRef<Path>>(file_path: T) -> anyhow::Result<(Vec<String
 }
 
 fn _get_chromsize<T: BufRead>(
-    rdr: &mut fasta::Reader<T>,
+    rdr: &mut fasta::io::Reader<T>,
 ) -> anyhow::Result<(Vec<String>, Vec<usize>)> {
     // get chromsize
     let mut seqname: Vec<String> = Vec::new();


### PR DESCRIPTION
## Description

This PR resolves a panic that occurred when processing fragmented Polars `Series` in `ChrRowSeqIter` and fixes the associated lifetime issues. This happens if calling `gr.transcripts()` on large grangers objects.

I also updated the dependencies. I stayed with polars v0.49.1 cuz v0.52.0 introduced too many breaking changes and leads to many bugs that can't be fixed right now.

I did not touch the version string. We should bump it when merging.



## The Problem:

When running on large GTF files (e.g., the full GENCODE annotation), the Polars `Series` for `start`, `end`, and `strand` columns could become heavily fragmented (e.g., >35,000 chunks).
- Panic: `Series::iter()` is optimized for contiguous memory and asserts `chunks.len() == 1`. This caused a panic on fragmented data.
- Lifetime Error: Attempting to fix the fragmentation by calling `.rechunk()` inside `new()` created a temporary `Series`. Returning an iterator that borrowed this temporary `Series` was impossible due to Rust's lifetime rules (the Series would be dropped at the end of the function).

## The Solution:

- Refactored `ChrRowSeqIter` to extract data into owned Vecs immediately during initialization:
start and end columns are collected into `Vec<Option<i64>>`.
- strand is parsed and stored as `Vec<Option<bool>>`.

This approach ensures the struct owns its data, resolving the lifetime issue, and avoids the Polars chunking requirement entirely.


## Validation:

- Successfully processed the full GRCh38 GTF annotation (3.2M records).
- Verified that output files (roers_ref.fa, gene_id_to_name.tsv, t2g_3col.tsv) are bit-for-bit identical to the current release for both splici (-a i) and gene-body (-a g) modes.